### PR TITLE
Orient inside extrusions perpendicularly

### DIFF
--- a/resources/ui_layout/default/extruder.ui
+++ b/resources/ui_layout/default/extruder.ui
@@ -43,12 +43,16 @@ group:Retraction wipe
 	setting:idx:retract_before_wipe
 	setting:idx:wipe_only_crossing
 group:General wipe
-	line:Wipe inside
-		setting:idx:label$At start:wipe_inside_start
-		setting:idx:label$At end:wipe_inside_end
-		setting:idx:label$Depth:wipe_inside_depth
-	end_line
-	setting:idx:wipe_extra_perimeter
+        line:Wipe inside
+                setting:idx:label$At start:wipe_inside_start
+                setting:idx:label$At end:wipe_inside_end
+                setting:idx:label$Depth:wipe_inside_depth
+        end_line
+        line:Extrude perimeter inside
+                setting:idx:extrude_perimeter_inside
+                setting:idx:label$Length:extrude_perimeter_inside_length
+        end_line
+        setting:idx:wipe_extra_perimeter
 	line:Wipe lift
 		setting:idx:label$height:wipe_lift
 		setting:idx:label$length:wipe_lift_length

--- a/resources/ui_layout/default/filament_override.ui
+++ b/resources/ui_layout/default/filament_override.ui
@@ -20,12 +20,14 @@ group:Retraction when tool is disabled
 group:Travel lift
 	setting:id$0:filament_wipe
 	setting:id$0:filament_retract_before_wipe
-	setting:id$0:filament_wipe_extra_perimeter
-	setting:id$0:filament_wipe_inside_depth
-	setting:id$0:filament_wipe_inside_end
-	setting:id$0:filament_wipe_inside_start
-	setting:id$0:filament_wipe_only_crossing
-	setting:id$0:filament_wipe_speed
-	setting:id$0:filament_wipe_lift
+        setting:id$0:filament_wipe_extra_perimeter
+        setting:id$0:filament_wipe_inside_depth
+        setting:id$0:filament_wipe_inside_end
+        setting:id$0:filament_wipe_inside_start
+        setting:id$0:filament_extrude_perimeter_inside
+        setting:id$0:filament_extrude_perimeter_inside_length
+        setting:id$0:filament_wipe_only_crossing
+        setting:id$0:filament_wipe_speed
+        setting:id$0:filament_wipe_lift
 group:Others
 	setting:id$0:filament_seam_gap

--- a/src/libslic3r/ExtrusionEntity.cpp
+++ b/src/libslic3r/ExtrusionEntity.cpp
@@ -379,6 +379,28 @@ ExtrusionPaths clip_end(ExtrusionPaths &paths, coordf_t distance)
     return removed;
 }
 
+ExtrusionPaths clip_start(ExtrusionPaths &paths, coordf_t distance)
+{
+    ExtrusionPaths removed;
+
+    while (distance > 0 && !paths.empty()) {
+        ExtrusionPath &first = paths.front();
+        removed.push_back(first);
+        coordf_t len = first.length();
+        if (len <= distance) {
+            paths.erase(paths.begin());
+            distance -= len;
+        } else {
+            first.polyline.clip_start(distance);
+            removed.back().polyline.clip_end(removed.back().polyline.length() - distance);
+            break;
+        }
+    }
+    for (auto &path : paths)
+        DEBUG_VISIT(path, LoopAssertVisitor())
+    return removed;
+}
+
 //bool ExtrusionLoop::has_overhang_point(const Point &point) const
 //{
 //    for (const ExtrusionPath &path : this->paths) {

--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -283,6 +283,7 @@ public:
 
 typedef std::vector<ExtrusionPath> ExtrusionPaths;
 ExtrusionPaths clip_end(ExtrusionPaths& paths, coordf_t distance);
+ExtrusionPaths clip_start(ExtrusionPaths& paths, coordf_t distance);
 
 class ExtrusionPath3D : public ExtrusionPath {
 protected:

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4107,7 +4107,7 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
 
     Point inward_point;
     //move the seam point inward a little bit
-    if (EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true) && paths.back().role().is_external_perimeter() && m_layer != NULL &&
+    if ((m_config.extrude_perimeter_inside || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) && paths.back().role().is_external_perimeter() && m_layer != NULL &&
         m_config.perimeters.value > 1 && paths.front().size() >= 2 && paths.back().polyline.size() >= 3) {
         // detect angle between last and first segment
         // the side depends on the original winding order of the polygon (left for contours, right for holes)
@@ -4123,10 +4123,15 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
         assert(ccw_angle_old_test(paths.front().first_point(), a, b) ==
                abs_angle(angle_ccw( a - paths.front().first_point(),b - paths.front().first_point())));
 #endif
-        double angle = abs_angle(angle_ccw(a-paths.front().first_point(),b-paths.front().first_point())) * 2 / 3;
-
-        // turn left if contour, turn right if hole
-        if (reverse_turn) angle *= -1;
+        double angle;
+        if (m_config.extrude_perimeter_inside)
+            angle = reverse_turn ? -PI / 2. : PI / 2.;
+        else {
+            angle = abs_angle(angle_ccw(a - paths.front().first_point(),
+                                       b - paths.front().first_point())) * 2 / 3;
+            if (reverse_turn)
+                angle *= -1;
+        }
 
         // create the destination point along the first segment and rotate it
         // we make sure we don't exceed the segment length because we don't know
@@ -4273,10 +4278,15 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
 #ifdef _DEBUG
         assert(ccw_angle_old_test(paths.front().first_point(), a, b) == abs_angle(angle_ccw( a - paths.front().first_point(),b - paths.front().first_point())));
 #endif
-        double angle = abs_angle(angle_ccw( a - paths.front().first_point(),b - paths.front().first_point())) / 3;
-
-        // turn left if contour, turn right if hole
-        if (reverse_turn) angle *= -1;
+        double angle;
+        if (m_config.extrude_perimeter_inside)
+            angle = reverse_turn ? -PI / 2. : PI / 2.;
+        else {
+            angle = abs_angle(angle_ccw(a - paths.front().first_point(),
+                                       b - paths.front().first_point())) / 3;
+            if (reverse_turn)
+                angle *= -1;
+        }
 
         // create the destination point along the first segment and rotate it
         // we make sure we don't exceed the segment length because we don't know
@@ -4919,7 +4929,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
 
     // generate the unretracting/wipe start move (same thing than for the end, but on the other side)
     assert(!wipe_paths.empty() && wipe_paths.front().size() > 1 && !wipe_paths.back().empty());
-    if (EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_start, true) && !wipe_paths.empty() && wipe_paths.front().size() > 1 && wipe_paths.back().size() > 1 && wipe_paths.front().role().is_external_perimeter()) {
+    if ((m_config.extrude_perimeter_inside || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_start, true)) && !wipe_paths.empty() && wipe_paths.front().size() > 1 && wipe_paths.back().size() > 1 && wipe_paths.front().role().is_external_perimeter()) {
         //note: previous & next are inverted to extrude "in the opposite direction, as we are "rewinding"
         //Point previous_point = wipe_paths.back().polyline.points.back();
         Point previous_point = wipe_paths.front().polyline.get_point_from_begin(std::min(wipe_paths.front().polyline.length() / 2, point_dist_for_vec));
@@ -4939,10 +4949,14 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             // swap points
             Point c = a; a = b; b = c;
         }
-        double angle = abs_angle(angle_ccw( a-current_point,b-current_point)) / 3;
-
-        // turn left if contour, turn right if hole
-        if (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) angle *= -1;
+        double angle;
+        if (m_config.extrude_perimeter_inside)
+            angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? -PI / 2. : PI / 2.;
+        else {
+            angle = abs_angle(angle_ccw(a - current_point, b - current_point)) / 3;
+            if (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw))
+                angle *= -1;
+        }
 
         // create the destination point along the first segment and rotate it
         // we make sure we don't exceed the segment length because we don't know
@@ -4951,8 +4965,11 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         Vec2d  next_pos = next_point.cast<double>();
         Vec2d  vec_dist = next_pos - current_pos;
         double vec_norm = vec_dist.norm();
-        const double setting_max_depth = (m_config.wipe_inside_depth.get_abs_value(m_writer.tool()->id(), nozzle_diam));
-        coordf_t dist = scale_d(nozzle_diam) / 2;
+        const double setting_max_depth = m_config.extrude_perimeter_inside
+            ? m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id())
+            : m_config.wipe_inside_depth.get_abs_value(m_writer.tool()->id(), nozzle_diam);
+        coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2
+                                               : scale_d(setting_max_depth);
         Point  pt = Point::round(current_pos + vec_dist * (2 * dist / vec_norm));
         pt.rotate(angle, current_point);
         //check if we can go to higher dist
@@ -4980,7 +4997,10 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         //this->set_last_pos(pt);
         // use extrude instead of travel_to_xy to trigger the unretract
         ExtrusionPath fake_path_wipe(ArcPolyline(Polyline{ pt , current_point }), wipe_paths.front().attributes(), wipe_paths.front().can_reverse());
-        fake_path_wipe.attributes_mutable().mm3_per_mm = 0;
+        if (m_config.extrude_perimeter_inside)
+            fake_path_wipe.attributes_mutable().mm3_per_mm = wipe_paths.front().mm3_per_mm();
+        else
+            fake_path_wipe.attributes_mutable().mm3_per_mm = 0;
         assert(!fake_path_wipe.can_reverse());
         // put travel before wipe (if ensure extrude_path don't do anything, then it's just an extra travel lost in the gcode).
         gcode += this->_travel_before_extrude(fake_path_wipe, "wipe", speed);
@@ -5136,10 +5156,14 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         double a2 = ccw_angle_old_test(current_point, a, b);
         assert(is_approx(abs_angle(angle_ccw( a-current_point,b-current_point)), ccw_angle_old_test(current_point, a, b), 0.000000001));
 #endif
-        double angle = abs_angle(angle_ccw( a-current_point,b-current_point)) / 3;
-        
-        // turn left if contour, turn right if hole
-        if (is_hole_loop ? is_full_loop_ccw : (!is_full_loop_ccw)) angle *= -1;
+        double angle;
+        if (m_config.extrude_perimeter_inside)
+            angle = (is_hole_loop ? is_full_loop_ccw : (!is_full_loop_ccw)) ? -PI / 2. : PI / 2.;
+        else {
+            angle = abs_angle(angle_ccw(a - current_point, b - current_point)) / 3;
+            if (is_hole_loop ? is_full_loop_ccw : (!is_full_loop_ccw))
+                angle *= -1;
+        }
 
         // create the destination point along the first segment and rotate it
         // we make sure we don't exceed the segment length because we don't know
@@ -5150,7 +5174,9 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         const double vec_norm = vec_dist.norm();
         double sin_a    = std::abs(std::sin(angle));
         sin_a = std::max(0.1, sin_a);
-        const double setting_max_depth = (m_config.wipe_inside_depth.get_abs_value(m_writer.tool()->id(), nozzle_diam));
+        const double setting_max_depth = m_config.extrude_perimeter_inside
+            ? m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id())
+            : m_config.wipe_inside_depth.get_abs_value(m_writer.tool()->id(), nozzle_diam);
         coordf_t dist   = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
         if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
             dist = coordf_t(check_wipe::max_depth(wipe_paths, scale_t(setting_max_depth), scale_t(nozzle_diam), 
@@ -5164,15 +5190,19 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         Point pt_inside = Point::round(/*(nd >= vec_norm) ? next_pos : */ (current_pos + vec_dist * ( dist / (vec_norm * sin_a))));
         pt_inside.rotate(angle, current_point);
 
-        if (EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) {
+        if (m_config.extrude_perimeter_inside || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) {
             if (!m_wipe.is_enabled()) {
                 if (!start_wipe.empty()) {
                     gcode += start_wipe;
                     start_wipe = "";
                 }
-                // generate the travel move
-                gcode += m_writer.travel_to_xy(this->point_to_gcode(pt_inside), 0.0, "move inwards before travel");
-                this->set_last_pos(pt_inside);
+                ExtrusionPath end_wipe(ArcPolyline(Polyline{ current_point, pt_inside }), wipe_paths.back().attributes(), wipe_paths.back().can_reverse());
+                if (m_config.extrude_perimeter_inside)
+                    end_wipe.attributes_mutable().mm3_per_mm = wipe_paths.back().mm3_per_mm();
+                else
+                    end_wipe.attributes_mutable().mm3_per_mm = 0;
+                gcode += this->_travel_before_extrude(end_wipe, "wipe", speed);
+                gcode += this->extrude_path(end_wipe, "move inwards before travel", speed);
             } else {
                 // also shift the wipe on retract if wipe_inside_end
                 // go to the inside (use clipper for easy shift)

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4758,7 +4758,10 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_
     Vec2d  vec_dist    = next_pos - current_pos;
     double vec_norm    = vec_dist.norm();
 
-    double angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? -PI / 2. : PI / 2.;
+    // Always rotate towards the interior of the printed object. The interior
+    // corresponds to the left side of the extrusion path regardless of the
+    // winding order of the loop, thus use a constant +90deg rotation.
+    double angle = PI / 2.;
     const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
     coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
     if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
@@ -4792,7 +4795,9 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_lo
     Vec2d  vec_dist    = current_pos - prev_pos;
     double vec_norm    = vec_dist.norm();
 
-    double angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? -PI / 2. : PI / 2.;
+    // Mirror logic of perimeter_inside_start: move inside using a constant
+    // 90deg turn irrespective of loop orientation.
+    double angle = PI / 2.;
     const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
     coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
     if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
@@ -4949,11 +4954,9 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             }
         }
     }
-    if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside)) {
-        coordf_t clip_inset = scale_(building_paths.front().width());
-        clip_start(building_paths, clip_inset);
-        clip_end(building_paths, clip_inset);
-    }
+    // When extruding a short path inside before and after the loop, do not
+    // modify the perimeter itself. The inside segments are tracked separately
+    // and the loop is printed in full so the configured length is preserved.
     if (building_paths.empty()) return "";
     if (building_paths.size() == 1)
         assert(is_full_loop_ccw == Polygon(building_paths.front().polyline.to_polyline().points).is_counter_clockwise());

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4821,7 +4821,7 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_
     Point pt = Point::round(current_pos + normal * dist);
 
     ExtrusionPath inside_path(ArcPolyline(Polyline{ pt, current_point }), paths.front().attributes(), false);
-    inside_path.attributes_mutable().mm3_per_mm = paths.front().mm3_per_mm();
+    inside_path.attributes_mutable().mm3_per_mm = paths.front().mm3_per_mm() * 0.9;
     gcode += this->_travel_before_extrude(inside_path, "perimeter inside start", speed);
     gcode += this->extrude_path(inside_path, "perimeter inside start", speed);
 }
@@ -4864,7 +4864,7 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_lo
     Point pt_inside = Point::round(current_pos + normal * dist);
 
     ExtrusionPath inside_path(ArcPolyline(Polyline{ current_point, pt_inside }), paths.back().attributes(), false);
-    inside_path.attributes_mutable().mm3_per_mm = paths.back().mm3_per_mm();
+    inside_path.attributes_mutable().mm3_per_mm = paths.back().mm3_per_mm() * 0.9;
     gcode += this->_travel_before_extrude(inside_path, "perimeter inside end", speed);
     gcode += this->extrude_path(inside_path, "perimeter inside end", speed);
     this->set_last_pos(pt_inside);

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4744,6 +4744,45 @@ void GCodeGenerator::seam_notch(const ExtrusionLoop& original_loop,
     for(auto &e : notch_extrusion_end) assert(e.polyline.empty() || e.polyline.is_valid());
 }
 
+static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
+        bool is_hole_loop, bool is_full_loop_ccw,
+        double nozzle_diam, double setting_max_depth)
+{
+    if (paths.empty() || paths.front().size() < 2 || paths.back().size() < 2)
+        return 0;
+
+    Point current_point = paths.front().first_point();
+    Point next_point    = paths.front().polyline.get_point(1);
+    Point prev_point    = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
+
+    Vec2d current_pos = current_point.cast<double>();
+
+    Vec2d dir_prev = (current_point.cast<double>() - prev_point.cast<double>());
+    Vec2d dir_next = (next_point.cast<double>() - current_point.cast<double>());
+    if (dir_prev.norm() == 0)
+        dir_prev = dir_next;
+    if (dir_next.norm() == 0)
+        dir_next = dir_prev;
+    dir_prev.normalize();
+    dir_next.normalize();
+    Vec2d tangent = dir_prev + dir_next;
+    if (tangent.squaredNorm() < 1e-12)
+        tangent = dir_next;
+    tangent.normalize();
+
+    double sign = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? 1. : -1.;
+    Vec2d normal(sign > 0 ? -tangent.y() : tangent.y(), sign > 0 ? tangent.x() : -tangent.x());
+    normal.normalize();
+
+    coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
+    if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
+        dist = coordf_t(check_wipe::max_depth(paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
+            [current_pos, normal](coord_t d)->Point {
+                return Point::round(current_pos + normal * d);
+            }));
+    return dist;
+}
+
 void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
 {
     if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty() || paths.front().size() < 2)
@@ -4969,7 +5008,18 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             }
         }
     }
-    if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) && original_loop.role().is_perimeter() && !is_hole_loop && !building_paths.empty()) {
+    bool apply_inside = false;
+    coordf_t inside_dist = 0;
+    if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) &&
+        original_loop.role().is_perimeter() && !is_hole_loop && !building_paths.empty()) {
+        const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
+        inside_dist = compute_inside_distance_start(building_paths, is_hole_loop, is_full_loop_ccw,
+                                                   nozzle_diam, setting_max_depth);
+        coordf_t threshold = coordf_t(scale_t(setting_max_depth)) / 4;
+        if (inside_dist >= threshold)
+            apply_inside = true;
+    }
+    if (apply_inside) {
         double inset_factor = original_loop.role().is_external_perimeter() ? 0.5 : 1.5 * std::max<size_t>(1, perimeter_idx);
         coordf_t inset = scale_(building_paths.front().width() * inset_factor);
         if (inset > 0 && inset < full_loop_length / 2) {
@@ -5018,7 +5068,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     coordf_t point_dist_for_vec = std::max(scale_t(nozzle_diam) / 100, scale_t(m_config.seam_gap.get_abs_value(m_writer.tool()->id(), nozzle_diam)) / 2);
     assert(point_dist_for_vec > 0);
 
-    if (original_loop.role().is_perimeter() && !is_hole_loop)
+    if (apply_inside)
         perimeter_inside_start(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
 
     // generate the unretracting/wipe start move (same thing than for the end, but on the other side)
@@ -5111,7 +5161,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         gcode += extrude_path(path, description, speed);
     }
 
-    if (original_loop.role().is_perimeter() && !is_hole_loop)
+    if (apply_inside)
         perimeter_inside_end(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
 
     // print seam tag with seam position (only for external perimeter & overhangs)

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3657,6 +3657,7 @@ void GCodeGenerator::process_layer_single_object(
             m_config.apply(print_object.config(), true);
             m_layer = layer_to_print.layer();
             m_print_object_instance_id = static_cast<uint16_t>(print_args.print_instance.instance_id);
+            m_object_layer_to_print_id = static_cast<uint16_t>(print_args.print_instance.object_layer_to_print_id);
             const PrintInstance &instance = print_object.instances()[print_args.print_instance.instance_id];
             if (print.config().avoid_crossing_perimeters)
                 m_avoid_crossing_perimeters.init_layer(*m_layer);
@@ -4774,6 +4775,8 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_
     inside_path.attributes_mutable().mm3_per_mm = paths.front().mm3_per_mm();
     gcode += this->_travel_before_extrude(inside_path, "perimeter inside start", speed);
     gcode += this->extrude_path(inside_path, "perimeter inside start", speed);
+    if (m_travel_obstacle_tracker.is_init())
+        m_travel_obstacle_tracker.mark_extruded(&inside_path, m_object_layer_to_print_id, m_print_object_instance_id);
 }
 
 void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
@@ -4806,6 +4809,8 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_lo
     inside_path.attributes_mutable().mm3_per_mm = paths.back().mm3_per_mm();
     gcode += this->_travel_before_extrude(inside_path, "perimeter inside end", speed);
     gcode += this->extrude_path(inside_path, "perimeter inside end", speed);
+    if (m_travel_obstacle_tracker.is_init())
+        m_travel_obstacle_tracker.mark_extruded(&inside_path, m_object_layer_to_print_id, m_print_object_instance_id);
     this->set_last_pos(pt_inside);
 }
 
@@ -5847,6 +5852,7 @@ void GCodeGenerator::set_region_for_extrude(const Print &print, const PrintObjec
 void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const LayerIsland &island, std::string &gcode)
 {
     m_seam_perimeters = true;
+    m_object_layer_to_print_id = static_cast<uint16_t>(print_args.print_instance.object_layer_to_print_id);
     const LayerRegion &layerm = *layer()->get_region(island.perimeters.region());
     // PrintObjects own the PrintRegions, thus the pointer to PrintRegion would be unique to a PrintObject, they would not
     // identify the content of PrintRegion accross the whole print uniquely. Translate to a Print specific PrintRegion.

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5073,7 +5073,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
 
     // generate the unretracting/wipe start move (same thing than for the end, but on the other side)
     assert(!wipe_paths.empty() && wipe_paths.front().size() > 1 && !wipe_paths.back().empty());
-    if (EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_start, true) && !wipe_paths.empty() && wipe_paths.front().size() > 1 && wipe_paths.back().size() > 1 && wipe_paths.front().role().is_external_perimeter()) {
+    if (!apply_inside && EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_start, true) && !wipe_paths.empty() && wipe_paths.front().size() > 1 && wipe_paths.back().size() > 1 && wipe_paths.front().role().is_external_perimeter()) {
         //note: previous & next are inverted to extrude "in the opposite direction, as we are "rewinding"
         //Point previous_point = wipe_paths.back().polyline.points.back();
         Point previous_point = wipe_paths.front().polyline.get_point_from_begin(std::min(wipe_paths.front().polyline.length() / 2, point_dist_for_vec));
@@ -5321,7 +5321,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         Point pt_inside = Point::round(/*(nd >= vec_norm) ? next_pos : */ (current_pos + vec_dist * ( dist / (vec_norm * sin_a))));
         pt_inside.rotate(angle, current_point);
 
-        if (EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) {
+        if (!apply_inside && EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) {
             if (!m_wipe.is_enabled()) {
                 if (!start_wipe.empty()) {
                     gcode += start_wipe;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4908,6 +4908,9 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     const Point seam_pos = loop_to_seam.first_point();
     const coordf_t full_loop_length = loop_to_seam.length();
     const bool is_full_loop_ccw = loop_to_seam.polygon().is_counter_clockwise();
+    size_t perimeter_idx = 0;
+    if (original_loop.role().is_perimeter())
+        perimeter_idx = m_perimeter_index++;
     //after that point, loop_to_seam can be modified by 'paths', so don't use it anymore
 #ifdef _DEBUG
     for (auto it = std::next(loop_to_seam.paths.begin()); it != loop_to_seam.paths.end(); ++it) {
@@ -4967,7 +4970,8 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         }
     }
     if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) && original_loop.role().is_perimeter() && !building_paths.empty()) {
-        coordf_t inset = scale_(building_paths.front().width() * (original_loop.role().is_external_perimeter() ? 0.5 : 1.5));
+        double inset_factor = original_loop.role().is_external_perimeter() ? 0.5 : 1.5 * std::max<size_t>(1, perimeter_idx);
+        coordf_t inset = scale_(building_paths.front().width() * inset_factor);
         if (inset > 0 && inset < full_loop_length / 2) {
             clip_start(building_paths, inset);
             clip_end(building_paths, inset);
@@ -5876,6 +5880,7 @@ void GCodeGenerator::set_region_for_extrude(const Print &print, const PrintObjec
 void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const LayerIsland &island, std::string &gcode)
 {
     m_seam_perimeters = true;
+    m_perimeter_index = 0;
     const LayerRegion &layerm = *layer()->get_region(island.perimeters.region());
     // PrintObjects own the PrintRegions, thus the pointer to PrintRegion would be unique to a PrintObject, they would not
     // identify the content of PrintRegion accross the whole print uniquely. Translate to a Print specific PrintRegion.

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4967,7 +4967,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         }
     }
     if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) && original_loop.role().is_perimeter() && !building_paths.empty()) {
-        coordf_t inset = scale_(building_paths.front().width() * (original_loop.role().is_external_perimeter() ? 0.5 : 1.0));
+        coordf_t inset = scale_(building_paths.front().width() * (original_loop.role().is_external_perimeter() ? 0.5 : 1.5));
         if (inset > 0 && inset < full_loop_length / 2) {
             clip_start(building_paths, inset);
             clip_end(building_paths, inset);

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4107,7 +4107,7 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
 
     Point inward_point;
     //move the seam point inward a little bit
-    if ((EXTRUDER_CONFIG_WITH_DEFAULT(extrude_perimeter_inside, false) || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) && paths.back().role().is_external_perimeter() && m_layer != NULL &&
+    if (EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true) && paths.back().role().is_external_perimeter() && m_layer != NULL &&
         m_config.perimeters.value > 1 && paths.front().size() >= 2 && paths.back().polyline.size() >= 3) {
         // detect angle between last and first segment
         // the side depends on the original winding order of the polygon (left for contours, right for holes)
@@ -4123,15 +4123,10 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
         assert(ccw_angle_old_test(paths.front().first_point(), a, b) ==
                abs_angle(angle_ccw( a - paths.front().first_point(),b - paths.front().first_point())));
 #endif
-        double angle;
-        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
-            angle = reverse_turn ? -PI / 2. : PI / 2.;
-        else {
-            angle = abs_angle(angle_ccw(a - paths.front().first_point(),
-                                       b - paths.front().first_point())) * 2 / 3;
-            if (reverse_turn)
-                angle *= -1;
-        }
+        double angle = abs_angle(angle_ccw(a-paths.front().first_point(),b-paths.front().first_point())) * 2 / 3;
+
+        // turn left if contour, turn right if hole
+        if (reverse_turn) angle *= -1;
 
         // create the destination point along the first segment and rotate it
         // we make sure we don't exceed the segment length because we don't know
@@ -4278,15 +4273,10 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
 #ifdef _DEBUG
         assert(ccw_angle_old_test(paths.front().first_point(), a, b) == abs_angle(angle_ccw( a - paths.front().first_point(),b - paths.front().first_point())));
 #endif
-        double angle;
-        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
-            angle = reverse_turn ? -PI / 2. : PI / 2.;
-        else {
-            angle = abs_angle(angle_ccw(a - paths.front().first_point(),
-                                       b - paths.front().first_point())) / 3;
-            if (reverse_turn)
-                angle *= -1;
-        }
+        double angle = abs_angle(angle_ccw( a - paths.front().first_point(),b - paths.front().first_point())) / 3;
+
+        // turn left if contour, turn right if hole
+        if (reverse_turn) angle *= -1;
 
         // create the destination point along the first segment and rotate it
         // we make sure we don't exceed the segment length because we don't know
@@ -4754,6 +4744,71 @@ void GCodeGenerator::seam_notch(const ExtrusionLoop& original_loop,
     for(auto &e : notch_extrusion_end) assert(e.polyline.empty() || e.polyline.is_valid());
 }
 
+void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
+{
+    if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || paths.empty() || paths.front().size() < 2)
+        return;
+
+    Point current_point = paths.front().first_point();
+    Point next_point    = paths.front().polyline.get_point(1);
+
+    Vec2d  current_pos = current_point.cast<double>();
+    Vec2d  next_pos    = next_point.cast<double>();
+    Vec2d  vec_dist    = next_pos - current_pos;
+    double vec_norm    = vec_dist.norm();
+
+    double angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? -PI / 2. : PI / 2.;
+    const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
+    coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
+    if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
+        dist = coordf_t(check_wipe::max_depth(paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
+            [current_pos, current_point, vec_dist, vec_norm, angle](coord_t dist)->Point {
+                Point pt = Point::round(current_pos + vec_dist * (dist / vec_norm));
+                pt.rotate(angle, current_point);
+                return pt;
+            }));
+    Point pt = Point::round(current_pos + vec_dist * (dist / vec_norm));
+    pt.rotate(angle, current_point);
+
+    ExtrusionPath inside_path(ArcPolyline(Polyline{ pt, current_point }), paths.front().attributes(), false);
+    inside_path.attributes_mutable().mm3_per_mm = paths.front().mm3_per_mm();
+    gcode += this->_travel_before_extrude(inside_path, "perimeter inside start", speed);
+    gcode += this->extrude_path(inside_path, "perimeter inside start", speed);
+}
+
+void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
+{
+    if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || paths.empty() || paths.back().size() < 2)
+        return;
+
+    Point current_point = paths.back().last_point();
+    Point prev_point    = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
+
+    Vec2d  current_pos = current_point.cast<double>();
+    Vec2d  prev_pos    = prev_point.cast<double>();
+    Vec2d  vec_dist    = current_pos - prev_pos;
+    double vec_norm    = vec_dist.norm();
+
+    double angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? -PI / 2. : PI / 2.;
+    const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
+    coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
+    if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
+        dist = coordf_t(check_wipe::max_depth(paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
+            [current_pos, current_point, vec_dist, vec_norm, angle](coord_t dist)->Point {
+                Point pt = Point::round(current_pos + vec_dist * (dist / vec_norm));
+                pt.rotate(angle, current_point);
+                return pt;
+            }));
+    Point pt_inside = Point::round(current_pos + vec_dist * (dist / vec_norm));
+    pt_inside.rotate(angle, current_point);
+
+    ExtrusionPath inside_path(ArcPolyline(Polyline{ current_point, pt_inside }), paths.back().attributes(), false);
+    inside_path.attributes_mutable().mm3_per_mm = paths.back().mm3_per_mm();
+    gcode += this->_travel_before_extrude(inside_path, "perimeter inside end", speed);
+    gcode += this->extrude_path(inside_path, "perimeter inside end", speed);
+    this->set_last_pos(pt_inside);
+}
+
 std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, const std::string_view description, double speed)
 {
     DEBUG_VISIT(original_loop, LoopAssertVisitor())
@@ -4889,6 +4944,11 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             }
         }
     }
+    if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside)) {
+        coordf_t clip_inset = scale_(building_paths.front().width());
+        clip_start(building_paths, clip_inset);
+        clip_end(building_paths, clip_inset);
+    }
     if (building_paths.empty()) return "";
     if (building_paths.size() == 1)
         assert(is_full_loop_ccw == Polygon(building_paths.front().polyline.to_polyline().points).is_counter_clockwise());
@@ -4927,9 +4987,11 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     coordf_t point_dist_for_vec = std::max(scale_t(nozzle_diam) / 100, scale_t(m_config.seam_gap.get_abs_value(m_writer.tool()->id(), nozzle_diam)) / 2);
     assert(point_dist_for_vec > 0);
 
+    perimeter_inside_start(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
+
     // generate the unretracting/wipe start move (same thing than for the end, but on the other side)
     assert(!wipe_paths.empty() && wipe_paths.front().size() > 1 && !wipe_paths.back().empty());
-    if ((BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_start, true)) && !wipe_paths.empty() && wipe_paths.front().size() > 1 && wipe_paths.back().size() > 1 && wipe_paths.front().role().is_external_perimeter()) {
+    if (EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_start, true) && !wipe_paths.empty() && wipe_paths.front().size() > 1 && wipe_paths.back().size() > 1 && wipe_paths.front().role().is_external_perimeter()) {
         //note: previous & next are inverted to extrude "in the opposite direction, as we are "rewinding"
         //Point previous_point = wipe_paths.back().polyline.points.back();
         Point previous_point = wipe_paths.front().polyline.get_point_from_begin(std::min(wipe_paths.front().polyline.length() / 2, point_dist_for_vec));
@@ -4949,14 +5011,10 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             // swap points
             Point c = a; a = b; b = c;
         }
-        double angle;
-        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
-            angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? -PI / 2. : PI / 2.;
-        else {
-            angle = abs_angle(angle_ccw(a - current_point, b - current_point)) / 3;
-            if (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw))
-                angle *= -1;
-        }
+        double angle = abs_angle(angle_ccw( a-current_point,b-current_point)) / 3;
+
+        // turn left if contour, turn right if hole
+        if (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) angle *= -1;
 
         // create the destination point along the first segment and rotate it
         // we make sure we don't exceed the segment length because we don't know
@@ -4965,11 +5023,8 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         Vec2d  next_pos = next_point.cast<double>();
         Vec2d  vec_dist = next_pos - current_pos;
         double vec_norm = vec_dist.norm();
-        const double setting_max_depth = EXTRUDER_CONFIG_WITH_DEFAULT(extrude_perimeter_inside, false)
-            ? m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id())
-            : m_config.wipe_inside_depth.get_abs_value(m_writer.tool()->id(), nozzle_diam);
-        coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2
-                                               : scale_d(setting_max_depth);
+        const double setting_max_depth = (m_config.wipe_inside_depth.get_abs_value(m_writer.tool()->id(), nozzle_diam));
+        coordf_t dist = scale_d(nozzle_diam) / 2;
         Point  pt = Point::round(current_pos + vec_dist * (2 * dist / vec_norm));
         pt.rotate(angle, current_point);
         //check if we can go to higher dist
@@ -4997,19 +5052,13 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         //this->set_last_pos(pt);
         // use extrude instead of travel_to_xy to trigger the unretract
         ExtrusionPath fake_path_wipe(ArcPolyline(Polyline{ pt , current_point }), wipe_paths.front().attributes(), wipe_paths.front().can_reverse());
-        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside)) {
-            fake_path_wipe.attributes_mutable().mm3_per_mm = wipe_paths.front().mm3_per_mm();
-            assert(!fake_path_wipe.can_reverse());
-            gcode += this->_travel_before_extrude(fake_path_wipe, "perimeter inside start", speed);
-            gcode += this->extrude_path(fake_path_wipe, "perimeter inside start", speed);
-        } else {
-            fake_path_wipe.attributes_mutable().mm3_per_mm = 0;
-            assert(!fake_path_wipe.can_reverse());
-            gcode += this->_travel_before_extrude(fake_path_wipe, "wipe", speed);
-            gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Wipe_Start) + "\n";
-            gcode += this->extrude_path(fake_path_wipe, "move inwards before retraction/seam", speed);
-            gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Wipe_End) + "\n";
-        }
+        fake_path_wipe.attributes_mutable().mm3_per_mm = 0;
+        assert(!fake_path_wipe.can_reverse());
+        // put travel before wipe (if ensure extrude_path don't do anything, then it's just an extra travel lost in the gcode).
+        gcode += this->_travel_before_extrude(fake_path_wipe, "wipe", speed);
+        gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Wipe_Start) + "\n";
+        gcode += this->extrude_path(fake_path_wipe, "move inwards before retraction/seam", speed);
+        gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Wipe_End) + "\n";
     }
     
     //extrusion notch start if any
@@ -5029,6 +5078,8 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         assert(!path.can_reverse());
         gcode += extrude_path(path, description, speed);
     }
+
+    perimeter_inside_end(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
 
     // print seam tag with seam position (only for external perimeter & overhangs)
     if (original_loop.paths.front().role().is_external_perimeter())
@@ -5159,14 +5210,10 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         double a2 = ccw_angle_old_test(current_point, a, b);
         assert(is_approx(abs_angle(angle_ccw( a-current_point,b-current_point)), ccw_angle_old_test(current_point, a, b), 0.000000001));
 #endif
-        double angle;
-        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
-            angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? -PI / 2. : PI / 2.;
-        else {
-            angle = abs_angle(angle_ccw(a - current_point, b - current_point)) / 3;
-            if (is_hole_loop ? is_full_loop_ccw : (!is_full_loop_ccw))
-                angle *= -1;
-        }
+        double angle = abs_angle(angle_ccw( a-current_point,b-current_point)) / 3;
+        
+        // turn left if contour, turn right if hole
+        if (is_hole_loop ? is_full_loop_ccw : (!is_full_loop_ccw)) angle *= -1;
 
         // create the destination point along the first segment and rotate it
         // we make sure we don't exceed the segment length because we don't know
@@ -5177,9 +5224,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         const double vec_norm = vec_dist.norm();
         double sin_a    = std::abs(std::sin(angle));
         sin_a = std::max(0.1, sin_a);
-        const double setting_max_depth = EXTRUDER_CONFIG_WITH_DEFAULT(extrude_perimeter_inside, false)
-            ? m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id())
-            : m_config.wipe_inside_depth.get_abs_value(m_writer.tool()->id(), nozzle_diam);
+        const double setting_max_depth = (m_config.wipe_inside_depth.get_abs_value(m_writer.tool()->id(), nozzle_diam));
         coordf_t dist   = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
         if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
             dist = coordf_t(check_wipe::max_depth(wipe_paths, scale_t(setting_max_depth), scale_t(nozzle_diam), 
@@ -5193,22 +5238,15 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         Point pt_inside = Point::round(/*(nd >= vec_norm) ? next_pos : */ (current_pos + vec_dist * ( dist / (vec_norm * sin_a))));
         pt_inside.rotate(angle, current_point);
 
-        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) {
+        if (EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) {
             if (!m_wipe.is_enabled()) {
                 if (!start_wipe.empty()) {
                     gcode += start_wipe;
                     start_wipe = "";
                 }
-                ExtrusionPath end_wipe(ArcPolyline(Polyline{ current_point, pt_inside }), wipe_paths.back().attributes(), wipe_paths.back().can_reverse());
-                if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside)) {
-                    end_wipe.attributes_mutable().mm3_per_mm = wipe_paths.back().mm3_per_mm();
-                    gcode += this->_travel_before_extrude(end_wipe, "perimeter inside end", speed);
-                    gcode += this->extrude_path(end_wipe, "perimeter inside end", speed);
-                } else {
-                    end_wipe.attributes_mutable().mm3_per_mm = 0;
-                    gcode += this->_travel_before_extrude(end_wipe, "wipe", speed);
-                    gcode += this->extrude_path(end_wipe, "move inwards before travel", speed);
-                }
+                // generate the travel move
+                gcode += m_writer.travel_to_xy(this->point_to_gcode(pt_inside), 0.0, "move inwards before travel");
+                this->set_last_pos(pt_inside);
             } else {
                 // also shift the wipe on retract if wipe_inside_end
                 // go to the inside (use clipper for easy shift)

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4107,7 +4107,7 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
 
     Point inward_point;
     //move the seam point inward a little bit
-    if ((m_config.extrude_perimeter_inside || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) && paths.back().role().is_external_perimeter() && m_layer != NULL &&
+    if ((EXTRUDER_CONFIG_WITH_DEFAULT(extrude_perimeter_inside, false) || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) && paths.back().role().is_external_perimeter() && m_layer != NULL &&
         m_config.perimeters.value > 1 && paths.front().size() >= 2 && paths.back().polyline.size() >= 3) {
         // detect angle between last and first segment
         // the side depends on the original winding order of the polygon (left for contours, right for holes)
@@ -4124,7 +4124,7 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
                abs_angle(angle_ccw( a - paths.front().first_point(),b - paths.front().first_point())));
 #endif
         double angle;
-        if (m_config.extrude_perimeter_inside)
+        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
             angle = reverse_turn ? -PI / 2. : PI / 2.;
         else {
             angle = abs_angle(angle_ccw(a - paths.front().first_point(),
@@ -4279,7 +4279,7 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
         assert(ccw_angle_old_test(paths.front().first_point(), a, b) == abs_angle(angle_ccw( a - paths.front().first_point(),b - paths.front().first_point())));
 #endif
         double angle;
-        if (m_config.extrude_perimeter_inside)
+        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
             angle = reverse_turn ? -PI / 2. : PI / 2.;
         else {
             angle = abs_angle(angle_ccw(a - paths.front().first_point(),
@@ -4929,7 +4929,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
 
     // generate the unretracting/wipe start move (same thing than for the end, but on the other side)
     assert(!wipe_paths.empty() && wipe_paths.front().size() > 1 && !wipe_paths.back().empty());
-    if ((m_config.extrude_perimeter_inside || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_start, true)) && !wipe_paths.empty() && wipe_paths.front().size() > 1 && wipe_paths.back().size() > 1 && wipe_paths.front().role().is_external_perimeter()) {
+    if ((EXTRUDER_CONFIG_WITH_DEFAULT(extrude_perimeter_inside, false) || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_start, true)) && !wipe_paths.empty() && wipe_paths.front().size() > 1 && wipe_paths.back().size() > 1 && wipe_paths.front().role().is_external_perimeter()) {
         //note: previous & next are inverted to extrude "in the opposite direction, as we are "rewinding"
         //Point previous_point = wipe_paths.back().polyline.points.back();
         Point previous_point = wipe_paths.front().polyline.get_point_from_begin(std::min(wipe_paths.front().polyline.length() / 2, point_dist_for_vec));
@@ -4950,7 +4950,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             Point c = a; a = b; b = c;
         }
         double angle;
-        if (m_config.extrude_perimeter_inside)
+        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
             angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? -PI / 2. : PI / 2.;
         else {
             angle = abs_angle(angle_ccw(a - current_point, b - current_point)) / 3;
@@ -4965,7 +4965,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         Vec2d  next_pos = next_point.cast<double>();
         Vec2d  vec_dist = next_pos - current_pos;
         double vec_norm = vec_dist.norm();
-        const double setting_max_depth = m_config.extrude_perimeter_inside
+        const double setting_max_depth = EXTRUDER_CONFIG_WITH_DEFAULT(extrude_perimeter_inside, false)
             ? m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id())
             : m_config.wipe_inside_depth.get_abs_value(m_writer.tool()->id(), nozzle_diam);
         coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2
@@ -4997,7 +4997,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         //this->set_last_pos(pt);
         // use extrude instead of travel_to_xy to trigger the unretract
         ExtrusionPath fake_path_wipe(ArcPolyline(Polyline{ pt , current_point }), wipe_paths.front().attributes(), wipe_paths.front().can_reverse());
-        if (m_config.extrude_perimeter_inside)
+        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
             fake_path_wipe.attributes_mutable().mm3_per_mm = wipe_paths.front().mm3_per_mm();
         else
             fake_path_wipe.attributes_mutable().mm3_per_mm = 0;
@@ -5157,7 +5157,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         assert(is_approx(abs_angle(angle_ccw( a-current_point,b-current_point)), ccw_angle_old_test(current_point, a, b), 0.000000001));
 #endif
         double angle;
-        if (m_config.extrude_perimeter_inside)
+        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
             angle = (is_hole_loop ? is_full_loop_ccw : (!is_full_loop_ccw)) ? -PI / 2. : PI / 2.;
         else {
             angle = abs_angle(angle_ccw(a - current_point, b - current_point)) / 3;
@@ -5174,7 +5174,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         const double vec_norm = vec_dist.norm();
         double sin_a    = std::abs(std::sin(angle));
         sin_a = std::max(0.1, sin_a);
-        const double setting_max_depth = m_config.extrude_perimeter_inside
+        const double setting_max_depth = EXTRUDER_CONFIG_WITH_DEFAULT(extrude_perimeter_inside, false)
             ? m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id())
             : m_config.wipe_inside_depth.get_abs_value(m_writer.tool()->id(), nozzle_diam);
         coordf_t dist   = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
@@ -5190,14 +5190,14 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         Point pt_inside = Point::round(/*(nd >= vec_norm) ? next_pos : */ (current_pos + vec_dist * ( dist / (vec_norm * sin_a))));
         pt_inside.rotate(angle, current_point);
 
-        if (m_config.extrude_perimeter_inside || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) {
+        if (EXTRUDER_CONFIG_WITH_DEFAULT(extrude_perimeter_inside, false) || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) {
             if (!m_wipe.is_enabled()) {
                 if (!start_wipe.empty()) {
                     gcode += start_wipe;
                     start_wipe = "";
                 }
                 ExtrusionPath end_wipe(ArcPolyline(Polyline{ current_point, pt_inside }), wipe_paths.back().attributes(), wipe_paths.back().can_reverse());
-                if (m_config.extrude_perimeter_inside)
+                if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
                     end_wipe.attributes_mutable().mm3_per_mm = wipe_paths.back().mm3_per_mm();
                 else
                     end_wipe.attributes_mutable().mm3_per_mm = 0;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4746,7 +4746,7 @@ void GCodeGenerator::seam_notch(const ExtrusionLoop& original_loop,
 
 void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
 {
-    if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || paths.empty() || paths.front().size() < 2)
+    if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty() || paths.front().size() < 2)
         return;
 
     Point current_point = paths.front().first_point();
@@ -4789,7 +4789,7 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_
 
 void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
 {
-    if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || paths.empty() || paths.back().size() < 2)
+    if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty() || paths.back().size() < 2)
         return;
 
     Point current_point = paths.back().last_point();
@@ -4909,7 +4909,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     const coordf_t full_loop_length = loop_to_seam.length();
     const bool is_full_loop_ccw = loop_to_seam.polygon().is_counter_clockwise();
     size_t perimeter_idx = 0;
-    if (original_loop.role().is_perimeter())
+    if (original_loop.role().is_perimeter() && !is_hole_loop)
         perimeter_idx = m_perimeter_index++;
     //after that point, loop_to_seam can be modified by 'paths', so don't use it anymore
 #ifdef _DEBUG
@@ -4969,7 +4969,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             }
         }
     }
-    if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) && original_loop.role().is_perimeter() && !building_paths.empty()) {
+    if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) && original_loop.role().is_perimeter() && !is_hole_loop && !building_paths.empty()) {
         double inset_factor = original_loop.role().is_external_perimeter() ? 0.5 : 1.5 * std::max<size_t>(1, perimeter_idx);
         coordf_t inset = scale_(building_paths.front().width() * inset_factor);
         if (inset > 0 && inset < full_loop_length / 2) {
@@ -5018,7 +5018,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     coordf_t point_dist_for_vec = std::max(scale_t(nozzle_diam) / 100, scale_t(m_config.seam_gap.get_abs_value(m_writer.tool()->id(), nozzle_diam)) / 2);
     assert(point_dist_for_vec > 0);
 
-    if (original_loop.role().is_perimeter())
+    if (original_loop.role().is_perimeter() && !is_hole_loop)
         perimeter_inside_start(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
 
     // generate the unretracting/wipe start move (same thing than for the end, but on the other side)
@@ -5111,7 +5111,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         gcode += extrude_path(path, description, speed);
     }
 
-    if (original_loop.role().is_perimeter())
+    if (original_loop.role().is_perimeter() && !is_hole_loop)
         perimeter_inside_end(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
 
     // print seam tag with seam position (only for external perimeter & overhangs)

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4966,7 +4966,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             }
         }
     }
-    if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) && !building_paths.empty()) {
+    if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) && original_loop.role().is_perimeter() && !building_paths.empty()) {
         coordf_t inset = scale_(building_paths.front().width() * (original_loop.role().is_external_perimeter() ? 0.5 : 1.0));
         if (inset > 0 && inset < full_loop_length / 2) {
             clip_start(building_paths, inset);
@@ -5014,7 +5014,8 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     coordf_t point_dist_for_vec = std::max(scale_t(nozzle_diam) / 100, scale_t(m_config.seam_gap.get_abs_value(m_writer.tool()->id(), nozzle_diam)) / 2);
     assert(point_dist_for_vec > 0);
 
-    perimeter_inside_start(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
+    if (original_loop.role().is_perimeter())
+        perimeter_inside_start(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
 
     // generate the unretracting/wipe start move (same thing than for the end, but on the other side)
     assert(!wipe_paths.empty() && wipe_paths.front().size() > 1 && !wipe_paths.back().empty());
@@ -5106,7 +5107,8 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         gcode += extrude_path(path, description, speed);
     }
 
-    perimeter_inside_end(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
+    if (original_loop.role().is_perimeter())
+        perimeter_inside_end(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
 
     // print seam tag with seam position (only for external perimeter & overhangs)
     if (original_loop.paths.front().role().is_external_perimeter())

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3657,7 +3657,6 @@ void GCodeGenerator::process_layer_single_object(
             m_config.apply(print_object.config(), true);
             m_layer = layer_to_print.layer();
             m_print_object_instance_id = static_cast<uint16_t>(print_args.print_instance.instance_id);
-            m_object_layer_to_print_id = static_cast<uint16_t>(print_args.print_instance.object_layer_to_print_id);
             const PrintInstance &instance = print_object.instances()[print_args.print_instance.instance_id];
             if (print.config().avoid_crossing_perimeters)
                 m_avoid_crossing_perimeters.init_layer(*m_layer);
@@ -4758,10 +4757,8 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_
     Vec2d  vec_dist    = next_pos - current_pos;
     double vec_norm    = vec_dist.norm();
 
-    // Always rotate towards the interior of the printed object. The interior
-    // corresponds to the left side of the extrusion path regardless of the
-    // winding order of the loop, thus use a constant +90deg rotation.
-    double angle = PI / 2.;
+    // Rotate by 90 degrees towards the loop interior.
+    double angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? PI / 2. : -PI / 2.;
     const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
     coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
     if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
@@ -4778,8 +4775,6 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_
     inside_path.attributes_mutable().mm3_per_mm = paths.front().mm3_per_mm();
     gcode += this->_travel_before_extrude(inside_path, "perimeter inside start", speed);
     gcode += this->extrude_path(inside_path, "perimeter inside start", speed);
-    if (m_travel_obstacle_tracker.is_init())
-        m_travel_obstacle_tracker.mark_extruded(&inside_path, m_object_layer_to_print_id, m_print_object_instance_id);
 }
 
 void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
@@ -4795,9 +4790,8 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_lo
     Vec2d  vec_dist    = current_pos - prev_pos;
     double vec_norm    = vec_dist.norm();
 
-    // Mirror logic of perimeter_inside_start: move inside using a constant
-    // 90deg turn irrespective of loop orientation.
-    double angle = PI / 2.;
+    // Mirror logic of perimeter_inside_start: rotate 90 degrees toward the loop interior.
+    double angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? PI / 2. : -PI / 2.;
     const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
     coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
     if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
@@ -4814,8 +4808,6 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_lo
     inside_path.attributes_mutable().mm3_per_mm = paths.back().mm3_per_mm();
     gcode += this->_travel_before_extrude(inside_path, "perimeter inside end", speed);
     gcode += this->extrude_path(inside_path, "perimeter inside end", speed);
-    if (m_travel_obstacle_tracker.is_init())
-        m_travel_obstacle_tracker.mark_extruded(&inside_path, m_object_layer_to_print_id, m_print_object_instance_id);
     this->set_last_pos(pt_inside);
 }
 
@@ -4952,6 +4944,13 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             } else {
                 clip_end(building_paths, clip_length);
             }
+        }
+    }
+    if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) && !building_paths.empty()) {
+        coordf_t inset = scale_(building_paths.front().width() * (original_loop.role().is_external_perimeter() ? 0.5 : 1.0));
+        if (inset > 0 && inset < full_loop_length / 2) {
+            clip_start(building_paths, inset);
+            clip_end(building_paths, inset);
         }
     }
     // When extruding a short path inside before and after the loop, do not
@@ -5855,7 +5854,6 @@ void GCodeGenerator::set_region_for_extrude(const Print &print, const PrintObjec
 void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const LayerIsland &island, std::string &gcode)
 {
     m_seam_perimeters = true;
-    m_object_layer_to_print_id = static_cast<uint16_t>(print_args.print_instance.object_layer_to_print_id);
     const LayerRegion &layerm = *layer()->get_region(island.perimeters.region());
     // PrintObjects own the PrintRegions, thus the pointer to PrintRegion would be unique to a PrintObject, they would not
     // identify the content of PrintRegion accross the whole print uniquely. Translate to a Print specific PrintRegion.

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4929,7 +4929,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
 
     // generate the unretracting/wipe start move (same thing than for the end, but on the other side)
     assert(!wipe_paths.empty() && wipe_paths.front().size() > 1 && !wipe_paths.back().empty());
-    if ((EXTRUDER_CONFIG_WITH_DEFAULT(extrude_perimeter_inside, false) || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_start, true)) && !wipe_paths.empty() && wipe_paths.front().size() > 1 && wipe_paths.back().size() > 1 && wipe_paths.front().role().is_external_perimeter()) {
+    if ((BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_start, true)) && !wipe_paths.empty() && wipe_paths.front().size() > 1 && wipe_paths.back().size() > 1 && wipe_paths.front().role().is_external_perimeter()) {
         //note: previous & next are inverted to extrude "in the opposite direction, as we are "rewinding"
         //Point previous_point = wipe_paths.back().polyline.points.back();
         Point previous_point = wipe_paths.front().polyline.get_point_from_begin(std::min(wipe_paths.front().polyline.length() / 2, point_dist_for_vec));
@@ -4997,16 +4997,19 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         //this->set_last_pos(pt);
         // use extrude instead of travel_to_xy to trigger the unretract
         ExtrusionPath fake_path_wipe(ArcPolyline(Polyline{ pt , current_point }), wipe_paths.front().attributes(), wipe_paths.front().can_reverse());
-        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
+        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside)) {
             fake_path_wipe.attributes_mutable().mm3_per_mm = wipe_paths.front().mm3_per_mm();
-        else
+            assert(!fake_path_wipe.can_reverse());
+            gcode += this->_travel_before_extrude(fake_path_wipe, "perimeter inside start", speed);
+            gcode += this->extrude_path(fake_path_wipe, "perimeter inside start", speed);
+        } else {
             fake_path_wipe.attributes_mutable().mm3_per_mm = 0;
-        assert(!fake_path_wipe.can_reverse());
-        // put travel before wipe (if ensure extrude_path don't do anything, then it's just an extra travel lost in the gcode).
-        gcode += this->_travel_before_extrude(fake_path_wipe, "wipe", speed);
-        gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Wipe_Start) + "\n";
-        gcode += this->extrude_path(fake_path_wipe, "move inwards before retraction/seam", speed);
-        gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Wipe_End) + "\n";
+            assert(!fake_path_wipe.can_reverse());
+            gcode += this->_travel_before_extrude(fake_path_wipe, "wipe", speed);
+            gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Wipe_Start) + "\n";
+            gcode += this->extrude_path(fake_path_wipe, "move inwards before retraction/seam", speed);
+            gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Wipe_End) + "\n";
+        }
     }
     
     //extrusion notch start if any
@@ -5158,7 +5161,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
 #endif
         double angle;
         if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
-            angle = (is_hole_loop ? is_full_loop_ccw : (!is_full_loop_ccw)) ? -PI / 2. : PI / 2.;
+            angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? -PI / 2. : PI / 2.;
         else {
             angle = abs_angle(angle_ccw(a - current_point, b - current_point)) / 3;
             if (is_hole_loop ? is_full_loop_ccw : (!is_full_loop_ccw))
@@ -5190,19 +5193,22 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         Point pt_inside = Point::round(/*(nd >= vec_norm) ? next_pos : */ (current_pos + vec_dist * ( dist / (vec_norm * sin_a))));
         pt_inside.rotate(angle, current_point);
 
-        if (EXTRUDER_CONFIG_WITH_DEFAULT(extrude_perimeter_inside, false) || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) {
+        if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) {
             if (!m_wipe.is_enabled()) {
                 if (!start_wipe.empty()) {
                     gcode += start_wipe;
                     start_wipe = "";
                 }
                 ExtrusionPath end_wipe(ArcPolyline(Polyline{ current_point, pt_inside }), wipe_paths.back().attributes(), wipe_paths.back().can_reverse());
-                if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside))
+                if (BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside)) {
                     end_wipe.attributes_mutable().mm3_per_mm = wipe_paths.back().mm3_per_mm();
-                else
+                    gcode += this->_travel_before_extrude(end_wipe, "perimeter inside end", speed);
+                    gcode += this->extrude_path(end_wipe, "perimeter inside end", speed);
+                } else {
                     end_wipe.attributes_mutable().mm3_per_mm = 0;
-                gcode += this->_travel_before_extrude(end_wipe, "wipe", speed);
-                gcode += this->extrude_path(end_wipe, "move inwards before travel", speed);
+                    gcode += this->_travel_before_extrude(end_wipe, "wipe", speed);
+                    gcode += this->extrude_path(end_wipe, "move inwards before travel", speed);
+                }
             } else {
                 // also shift the wipe on retract if wipe_inside_end
                 // go to the inside (use clipper for easy shift)

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4751,25 +4751,35 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_
 
     Point current_point = paths.front().first_point();
     Point next_point    = paths.front().polyline.get_point(1);
+    Point prev_point    = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
 
-    Vec2d  current_pos = current_point.cast<double>();
-    Vec2d  next_pos    = next_point.cast<double>();
-    Vec2d  vec_dist    = next_pos - current_pos;
-    double vec_norm    = vec_dist.norm();
+    Vec2d current_pos = current_point.cast<double>();
 
-    // Rotate by 90 degrees towards the loop interior.
-    double angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? PI / 2. : -PI / 2.;
+    Vec2d dir_prev = (current_point.cast<double>() - prev_point.cast<double>());
+    Vec2d dir_next = (next_point.cast<double>() - current_point.cast<double>());
+    if (dir_prev.norm() == 0)
+        dir_prev = dir_next;
+    if (dir_next.norm() == 0)
+        dir_next = dir_prev;
+    dir_prev.normalize();
+    dir_next.normalize();
+    Vec2d tangent = dir_prev + dir_next;
+    if (tangent.squaredNorm() < 1e-12)
+        tangent = dir_next;
+    tangent.normalize();
+
+    double sign = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? 1. : -1.;
+    Vec2d normal(sign > 0 ? -tangent.y() : tangent.y(), sign > 0 ? tangent.x() : -tangent.x());
+    normal.normalize();
+
     const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
     coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
     if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
         dist = coordf_t(check_wipe::max_depth(paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
-            [current_pos, current_point, vec_dist, vec_norm, angle](coord_t dist)->Point {
-                Point pt = Point::round(current_pos + vec_dist * (dist / vec_norm));
-                pt.rotate(angle, current_point);
-                return pt;
+            [current_pos, normal](coord_t dist)->Point {
+                return Point::round(current_pos + normal * dist);
             }));
-    Point pt = Point::round(current_pos + vec_dist * (dist / vec_norm));
-    pt.rotate(angle, current_point);
+    Point pt = Point::round(current_pos + normal * dist);
 
     ExtrusionPath inside_path(ArcPolyline(Polyline{ pt, current_point }), paths.front().attributes(), false);
     inside_path.attributes_mutable().mm3_per_mm = paths.front().mm3_per_mm();
@@ -4784,25 +4794,35 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_lo
 
     Point current_point = paths.back().last_point();
     Point prev_point    = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
+    Point next_point    = paths.front().polyline.get_point(1);
 
-    Vec2d  current_pos = current_point.cast<double>();
-    Vec2d  prev_pos    = prev_point.cast<double>();
-    Vec2d  vec_dist    = current_pos - prev_pos;
-    double vec_norm    = vec_dist.norm();
+    Vec2d current_pos = current_point.cast<double>();
 
-    // Mirror logic of perimeter_inside_start: rotate 90 degrees toward the loop interior.
-    double angle = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? PI / 2. : -PI / 2.;
+    Vec2d dir_prev = (current_point.cast<double>() - prev_point.cast<double>());
+    Vec2d dir_next = (next_point.cast<double>() - current_point.cast<double>());
+    if (dir_prev.norm() == 0)
+        dir_prev = dir_next;
+    if (dir_next.norm() == 0)
+        dir_next = dir_prev;
+    dir_prev.normalize();
+    dir_next.normalize();
+    Vec2d tangent = dir_prev + dir_next;
+    if (tangent.squaredNorm() < 1e-12)
+        tangent = dir_prev;
+    tangent.normalize();
+
+    double sign = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? 1. : -1.;
+    Vec2d normal(sign > 0 ? -tangent.y() : tangent.y(), sign > 0 ? tangent.x() : -tangent.x());
+    normal.normalize();
+
     const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
     coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
     if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
         dist = coordf_t(check_wipe::max_depth(paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
-            [current_pos, current_point, vec_dist, vec_norm, angle](coord_t dist)->Point {
-                Point pt = Point::round(current_pos + vec_dist * (dist / vec_norm));
-                pt.rotate(angle, current_point);
-                return pt;
+            [current_pos, normal](coord_t dist)->Point {
+                return Point::round(current_pos + normal * dist);
             }));
-    Point pt_inside = Point::round(current_pos + vec_dist * (dist / vec_norm));
-    pt_inside.rotate(angle, current_point);
+    Point pt_inside = Point::round(current_pos + normal * dist);
 
     ExtrusionPath inside_path(ArcPolyline(Polyline{ current_point, pt_inside }), paths.back().attributes(), false);
     inside_path.attributes_mutable().mm3_per_mm = paths.back().mm3_per_mm();

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -310,6 +310,8 @@ private:
     void            add_wipe_points(const std::vector<THING>& paths, bool reverse, bool is_loop);
     void            seam_notch(const ExtrusionLoop& original_loop, ExtrusionPaths& building_paths,
         ExtrusionPaths& notch_extrusion_start, ExtrusionPaths& notch_extrusion_end, bool is_hole_loop, bool is_full_loop_ccw);
+    void            perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
+    void            perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
 
 
 	struct InstanceToPrint

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -558,7 +558,6 @@ private:
     std::string                         m_pending_pre_extrusion_gcode;
     // Pointer to currently exporting PrintObject and instance index.
     GCode::PrintObjectInstance          m_current_instance;
-    uint16_t                            m_object_layer_to_print_id = 0;
 
     // ordered list of object, to give them a unique id.
     std::vector<const PrintObject*> m_ordered_objects;

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -474,6 +474,8 @@ private:
     uint32_t                            m_layer_with_support_count;
     // Progress bar indicator. Increments from -1 up to layer_count.
     int                                 m_layer_index;
+    // Sequential index of the current perimeter being printed within a layer
+    size_t                              m_perimeter_index{0};
     // Current layer processed. In sequential printing mode, only a single copy will be printed.
     // In non-sequential mode, all its copies will be printed.
     const Layer*                        m_layer;

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -558,6 +558,7 @@ private:
     std::string                         m_pending_pre_extrusion_gcode;
     // Pointer to currently exporting PrintObject and instance index.
     GCode::PrintObjectInstance          m_current_instance;
+    uint16_t                            m_object_layer_to_print_id = 0;
 
     // ordered list of object, to give them a unique id.
     std::vector<const PrintObject*> m_ordered_objects;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -6845,6 +6845,24 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvancedE | comSuSi;
     def->is_vector_extruder = true;
     def->set_default_value(new ConfigOptionPercents{ 50 });
+
+    def = this->add("extrude_perimeter_inside", coBools);
+    def->label = L("Extrude perimeter inside");
+    def->category = OptionCategory::extruders;
+    def->tooltip = L("Extrude a short segment inside the object before starting and after finishing external perimeters.");
+    def->mode = comAdvancedE | comSuSi;
+    def->is_vector_extruder = true;
+    def->set_default_value(new ConfigOptionBools{ false });
+
+    def = this->add("extrude_perimeter_inside_length", coFloats);
+    def->label = L("Extrude inside length");
+    def->category = OptionCategory::extruders;
+    def->tooltip = L("Length of the inside extrusion segment for the perimeter start/end.");
+    def->sidetext = L("mm");
+    def->min = 0;
+    def->mode = comAdvancedE | comSuSi;
+    def->is_vector_extruder = true;
+    def->set_default_value(new ConfigOptionFloats{ 0.5f });
     
     def = this->add("wipe_lift", coFloatsOrPercents);
     def->label = L("Wipe lift");
@@ -7379,6 +7397,8 @@ void PrintConfigDef::init_extruder_option_keys()
     m_extruder_option_keys = {
         "default_filament_profile",
         "deretract_speed",
+        "extrude_perimeter_inside",
+        "extrude_perimeter_inside_length",
         "extruder_colour",
         "extruder_extrusion_multiplier_speed",
         "extruder_fan_offset",
@@ -7423,6 +7443,8 @@ void PrintConfigDef::init_extruder_option_keys()
 
     m_extruder_retract_keys = {
         "deretract_speed",
+        "extrude_perimeter_inside",
+        "extrude_perimeter_inside_length",
         "retract_before_travel",
         "retract_before_wipe",
         "retract_layer_change",
@@ -7457,6 +7479,8 @@ void PrintConfigDef::init_extruder_option_keys()
     assert(std::is_sorted(m_extruder_retract_keys.begin(), m_extruder_retract_keys.end()));
     m_filament_override_option_keys = {
         "deretract_speed",
+        "extrude_perimeter_inside",
+        "extrude_perimeter_inside_length",
         "retract_before_travel",
         "retract_before_wipe",
         "retract_layer_change",

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1086,6 +1086,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionPercents,            extruder_fan_offset))
     ((ConfigOptionPoints,              extruder_offset))
     ((ConfigOptionFloats,              extruder_temperature_offset))
+    ((ConfigOptionBools,               extrude_perimeter_inside))
+    ((ConfigOptionFloats,              extrude_perimeter_inside_length))
     ((ConfigOptionString,              extrusion_axis))
     ((ConfigOptionFloats,              extrusion_multiplier))
     ((ConfigOptionFloat,               fan_kickstart))


### PR DESCRIPTION
## Summary
- rotate the start and end wipe-in paths by 90°
- respect `extrude_perimeter_inside_length` as the maximum distance
- keep wipe-inside angle calculation unchanged unless extruding inside

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870bfee8ab4832cba9cc7086d60e28a