### PR TITLE
Maintain inside extrusions after first activation

### DIFF
--- a/resources/ui_layout/default/extruder.ui
+++ b/resources/ui_layout/default/extruder.ui
@@ -43,12 +43,16 @@ group:Retraction wipe
 	setting:idx:retract_before_wipe
 	setting:idx:wipe_only_crossing
 group:General wipe
-	line:Wipe inside
-		setting:idx:label$At start:wipe_inside_start
-		setting:idx:label$At end:wipe_inside_end
-		setting:idx:label$Depth:wipe_inside_depth
-	end_line
-	setting:idx:wipe_extra_perimeter
+        line:Wipe inside
+                setting:idx:label$At start:wipe_inside_start
+                setting:idx:label$At end:wipe_inside_end
+                setting:idx:label$Depth:wipe_inside_depth
+        end_line
+        line:Extrude perimeter inside
+                setting:idx:extrude_perimeter_inside
+                setting:idx:label$Length:extrude_perimeter_inside_length
+        end_line
+        setting:idx:wipe_extra_perimeter
 	line:Wipe lift
 		setting:idx:label$height:wipe_lift
 		setting:idx:label$length:wipe_lift_length

--- a/resources/ui_layout/default/filament_override.ui
+++ b/resources/ui_layout/default/filament_override.ui
@@ -20,12 +20,14 @@ group:Retraction when tool is disabled
 group:Travel lift
 	setting:id$0:filament_wipe
 	setting:id$0:filament_retract_before_wipe
-	setting:id$0:filament_wipe_extra_perimeter
-	setting:id$0:filament_wipe_inside_depth
-	setting:id$0:filament_wipe_inside_end
-	setting:id$0:filament_wipe_inside_start
-	setting:id$0:filament_wipe_only_crossing
-	setting:id$0:filament_wipe_speed
-	setting:id$0:filament_wipe_lift
+        setting:id$0:filament_wipe_extra_perimeter
+        setting:id$0:filament_wipe_inside_depth
+        setting:id$0:filament_wipe_inside_end
+        setting:id$0:filament_wipe_inside_start
+        setting:id$0:filament_extrude_perimeter_inside
+        setting:id$0:filament_extrude_perimeter_inside_length
+        setting:id$0:filament_wipe_only_crossing
+        setting:id$0:filament_wipe_speed
+        setting:id$0:filament_wipe_lift
 group:Others
 	setting:id$0:filament_seam_gap

--- a/src/libslic3r/ExtrusionEntity.cpp
+++ b/src/libslic3r/ExtrusionEntity.cpp
@@ -379,6 +379,28 @@ ExtrusionPaths clip_end(ExtrusionPaths &paths, coordf_t distance)
     return removed;
 }
 
+ExtrusionPaths clip_start(ExtrusionPaths &paths, coordf_t distance)
+{
+    ExtrusionPaths removed;
+
+    while (distance > 0 && !paths.empty()) {
+        ExtrusionPath &first = paths.front();
+        removed.push_back(first);
+        coordf_t len = first.length();
+        if (len <= distance) {
+            paths.erase(paths.begin());
+            distance -= len;
+        } else {
+            first.polyline.clip_start(distance);
+            removed.back().polyline.clip_end(removed.back().polyline.length() - distance);
+            break;
+        }
+    }
+    for (auto &path : paths)
+        DEBUG_VISIT(path, LoopAssertVisitor())
+    return removed;
+}
+
 //bool ExtrusionLoop::has_overhang_point(const Point &point) const
 //{
 //    for (const ExtrusionPath &path : this->paths) {

--- a/src/libslic3r/ExtrusionEntity.hpp
+++ b/src/libslic3r/ExtrusionEntity.hpp
@@ -283,6 +283,7 @@ public:
 
 typedef std::vector<ExtrusionPath> ExtrusionPaths;
 ExtrusionPaths clip_end(ExtrusionPaths& paths, coordf_t distance);
+ExtrusionPaths clip_start(ExtrusionPaths& paths, coordf_t distance);
 
 class ExtrusionPath3D : public ExtrusionPath {
 protected:

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5153,7 +5153,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         inside_dist = compute_inside_distance_start(building_paths, &loop_polygon,
                                                    is_hole_loop, is_full_loop_ccw,
                                                    nozzle_diam, setting_max_depth, &inside_point);
-        coordf_t threshold = scale_d(setting_max_depth) / 4;
+        coordf_t threshold = scale_d(nozzle_diam) * 2;
         bool cross_solid = false;
         if (!m_layer_solid_surfaces.empty()) {
             for (const ExPolygon &ep : m_layer_solid_surfaces) {

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4051,7 +4051,8 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
     bool is_hole_loop = (loop_to_seam.loop_role() & ExtrusionLoopRole::elrHole) != 0;// loop.make_counter_clockwise();
     bool reverse_turn = loop_to_seam.polygon().is_clockwise() ^ is_hole_loop;
 
-    split_at_seam_pos(loop_to_seam, reverse_turn);
+    split_at_seam_pos(loop_to_seam, reverse_turn, m_perimeter_index);
+    Point seam_pos = loop_to_seam.first_point();
     const coordf_t full_loop_length = loop_to_seam.length();
 
     // don't clip the path ?
@@ -4300,12 +4301,17 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
         gcode += m_writer.travel_to_xy(this->point_to_gcode(inward_point), 0.0, "move inwards before travel");
     }
 
+    if (m_last_seam_positions.size() <= m_perimeter_index)
+        m_last_seam_positions.resize(m_perimeter_index + 1);
+    m_last_seam_positions[m_perimeter_index] = seam_pos;
+    ++m_perimeter_index;
+
     assert(!this->visitor_flipped);
     this->visitor_flipped = save_flipped;
     return gcode;
 }
 
-void GCodeGenerator::split_at_seam_pos(ExtrusionLoop& loop, bool was_clockwise)
+void GCodeGenerator::split_at_seam_pos(ExtrusionLoop& loop, bool was_clockwise, size_t perimeter_idx)
 {
     if (loop.paths.empty())
         return;
@@ -4358,6 +4364,23 @@ void GCodeGenerator::split_at_seam_pos(ExtrusionLoop& loop, bool was_clockwise)
             //m_print_object_instance_id,
             //lower_layer_edge_grid ? lower_layer_edge_grid->get() : nullptr
             );
+        if (perimeter_idx < m_last_seam_positions.size()) {
+            coord_t nozzle = scale_(EXTRUDER_CONFIG_WITH_DEFAULT(nozzle_diameter, 0.4));
+            if (nozzle > 0) {
+                coord_t max_jump = nozzle * 5;
+                coord_t max_delta = nozzle / 8;
+                const Point &prev = m_last_seam_positions[perimeter_idx];
+                coord_t dist = seam_point.distance_to(prev);
+                if (dist <= max_jump) {
+                    if (dist > max_delta) {
+                        Vec2d move = (seam_point.cast<double>() - prev.cast<double>()).normalized() * unscaled<double>(max_delta);
+                        seam_point = Point::round(prev.cast<double>() + move);
+                    } else {
+                        seam_point = prev;
+                    }
+                }
+            }
+        }
         // Because the G-code export has 1um resolution, don't generate segments shorter than "1.5 microns" (depends of gcode_precision_xyz)
         //FIXME use settings
         if (!loop.split_at_vertex(seam_point, scaled<double>(0.0015))) {
@@ -5073,13 +5096,11 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         for (int i = 1; i < path.polyline.size(); ++i)
             assert(!path.polyline.get_point(i - 1).coincides_with_epsilon(path.polyline.get_point(i)));
 
-    split_at_seam_pos(loop_to_seam, is_hole_loop);
+    split_at_seam_pos(loop_to_seam, is_hole_loop, m_perimeter_index);
     const Point seam_pos = loop_to_seam.first_point();
     const coordf_t full_loop_length = loop_to_seam.length();
     const bool is_full_loop_ccw = loop_to_seam.polygon().is_counter_clockwise();
-    size_t perimeter_idx = 0;
-    if ((original_loop.role().is_perimeter() || original_loop.role().is_mixed()) && !is_hole_loop)
-        perimeter_idx = m_perimeter_index++;
+    size_t perimeter_idx = m_perimeter_index;
     //after that point, loop_to_seam can be modified by 'paths', so don't use it anymore
 #ifdef _DEBUG
     for (auto it = std::next(loop_to_seam.paths.begin()); it != loop_to_seam.paths.end(); ++it) {
@@ -5671,6 +5692,12 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Wipe_End) + "\n";
         }
     }
+    if ((original_loop.role().is_perimeter() || original_loop.role().is_mixed()) && !is_hole_loop) {
+        if (m_last_seam_positions.size() <= perimeter_idx)
+            m_last_seam_positions.resize(perimeter_idx + 1);
+        m_last_seam_positions[perimeter_idx] = seam_pos;
+        ++m_perimeter_index;
+    }
 stop_print_loop:
 
     assert(!this->visitor_flipped);
@@ -6086,6 +6113,8 @@ void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const Lay
     m_seam_perimeters = true;
     m_perimeter_index = 0;
     m_apply_inside_layer = false;
+    if (layer()->id() == 0)
+        m_last_seam_positions.clear();
     m_current_object_layer_idx = print_args.print_instance.object_layer_to_print_id;
     m_current_instance_idx     = print_args.print_instance.instance_id;
     m_layer_solid_surfaces.clear();

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4755,7 +4755,7 @@ static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
         double nozzle_diam, double setting_max_depth,
         Point *inside_pt = nullptr)
 {
-    if (paths.empty() || paths.front().size() < 2 || paths.back().size() < 2)
+    if (paths.empty())
         return 0;
 
     Point current_point = paths.front().first_point();
@@ -4786,18 +4786,11 @@ static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
 
     Vec2d current_pos = current_point.cast<double>();
 
-    Vec2d dir_prev = (current_point.cast<double>() - prev_point.cast<double>());
-    Vec2d dir_next = (next_point.cast<double>() - current_point.cast<double>());
-    if (dir_prev.norm() == 0)
-        dir_prev = dir_next;
-    if (dir_next.norm() == 0)
-        dir_next = dir_prev;
-    dir_prev.normalize();
-    dir_next.normalize();
-    Vec2d tangent = dir_prev + dir_next;
-    if (tangent.squaredNorm() < 1e-12)
-        tangent = dir_next;
-    tangent.normalize();
+    Vec2d tangent = (next_point.cast<double>() - current_point.cast<double>());
+    if (tangent.norm() == 0)
+        tangent = (current_point.cast<double>() - prev_point.cast<double>());
+    if (tangent.norm() != 0)
+        tangent.normalize();
 
     double sign = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? 1. : -1.;
     Vec2d normal(sign > 0 ? -tangent.y() : tangent.y(), sign > 0 ? tangent.x() : -tangent.x());
@@ -4862,18 +4855,11 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon
 
     Vec2d current_pos = current_point.cast<double>();
 
-    Vec2d dir_prev = (current_point.cast<double>() - prev_point.cast<double>());
-    Vec2d dir_next = (next_point.cast<double>() - current_point.cast<double>());
-    if (dir_prev.norm() == 0)
-        dir_prev = dir_next;
-    if (dir_next.norm() == 0)
-        dir_next = dir_prev;
-    dir_prev.normalize();
-    dir_next.normalize();
-    Vec2d tangent = dir_prev + dir_next;
-    if (tangent.squaredNorm() < 1e-12)
-        tangent = dir_next;
-    tangent.normalize();
+    Vec2d tangent = (next_point.cast<double>() - current_point.cast<double>());
+    if (tangent.norm() == 0)
+        tangent = (current_point.cast<double>() - prev_point.cast<double>());
+    if (tangent.norm() != 0)
+        tangent.normalize();
 
     double sign = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? 1. : -1.;
     Vec2d normal(sign > 0 ? -tangent.y() : tangent.y(), sign > 0 ? tangent.x() : -tangent.x());
@@ -4944,18 +4930,11 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, const Polygon* 
 
     Vec2d current_pos = current_point.cast<double>();
 
-    Vec2d dir_prev = (current_point.cast<double>() - prev_point.cast<double>());
-    Vec2d dir_next = (next_point.cast<double>() - current_point.cast<double>());
-    if (dir_prev.norm() == 0)
-        dir_prev = dir_next;
-    if (dir_next.norm() == 0)
-        dir_next = dir_prev;
-    dir_prev.normalize();
-    dir_next.normalize();
-    Vec2d tangent = dir_prev + dir_next;
-    if (tangent.squaredNorm() < 1e-12)
-        tangent = dir_prev;
-    tangent.normalize();
+    Vec2d tangent = (current_point.cast<double>() - prev_point.cast<double>());
+    if (tangent.norm() == 0)
+        tangent = (next_point.cast<double>() - current_point.cast<double>());
+    if (tangent.norm() != 0)
+        tangent.normalize();
 
     double sign = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? 1. : -1.;
     Vec2d normal(sign > 0 ? -tangent.y() : tangent.y(), sign > 0 ? tangent.x() : -tangent.x());

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5086,7 +5086,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         // multiples of half a width moving inwards.
         size_t perims_cfg = m_region ? m_region->config().perimeters.value : 1;
         bool   outer_first = m_region ? m_region->config().external_perimeters_first.value : true;
-        double inset_factor = 0.5 * (outer_first ? double(perimeter_idx + 1)
+        double inset_factor = -0.5 + (outer_first ? double(perimeter_idx + 1)
                                                  : std::max(1.0, double(perims_cfg - perimeter_idx)));
         coordf_t inset = scale_(building_paths.front().width() * inset_factor);
         if (inset > 0 && inset < full_loop_length / 2) {

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4860,19 +4860,6 @@ coordf_t GCodeGenerator::limit_by_island(const Point& start, const Vec2d& normal
     return coordf_t(min_dist);
 }
 
-bool GCodeGenerator::line_inside_island(const Line& line) const
-{
-    if (m_current_island_polygons.empty())
-        return true;
-    // The generic ExPolygon::contains(Line) may fail when the line starts or
-    // ends on the polygon boundary. Test the end points explicitly and rely on
-    // limit_by_island() to avoid crossing island borders.
-    for (const ExPolygon &ep : m_current_island_polygons)
-        if (ep.contains(line.a, true) && ep.contains(line.b, true))
-            return true;
-    return false;
-}
-
 void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
 {
     if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty())
@@ -4945,11 +4932,7 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon
             dist = std::max(dist, dist_poly);
         }
     }
-    dist = limit_by_island(current_point, normal, dist);
     Point pt = Point::round(current_pos + normal * dist);
-
-    if (!line_inside_island(Line(current_point, pt)))
-        return;
 
     ExtrusionPath inside_path(ArcPolyline(Polyline{ pt, current_point }), paths.front().attributes(), false);
     inside_path.attributes_mutable().mm3_per_mm = paths.front().mm3_per_mm() * 0.9;
@@ -5033,11 +5016,7 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, const Polygon* 
             dist = std::max(dist, dist_poly);
         }
     }
-    dist = limit_by_island(current_point, normal, dist);
     Point pt_inside = Point::round(current_pos + normal * dist);
-
-    if (!line_inside_island(Line(current_point, pt_inside)))
-        return;
 
     ExtrusionPath inside_path(ArcPolyline(Polyline{ current_point, pt_inside }), paths.back().attributes(), false);
     inside_path.attributes_mutable().mm3_per_mm = paths.back().mm3_per_mm() * 0.9;
@@ -5201,9 +5180,16 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             double len = normal_vec.norm();
             if (len > 0) {
                 normal_vec /= len;
-                inside_dist = limit_by_island(building_paths.front().first_point(), normal_vec, inside_dist);
                 inside_point = Point::round(building_paths.front().first_point().cast<double>() + normal_vec * inside_dist);
-                if (!line_inside_island(Line(building_paths.front().first_point(), inside_point)))
+                bool is_inside = false;
+                for ( ExPolygon &ep : m_current_island_polygons) {
+                    // check if the point is inside the island polygons
+                    // if it is, we can apply the inside extrusion
+                    is_inside = ep.contains(inside_point, true);
+                    if (is_inside) break;
+                }
+                //original_loop.polygon().contains(inside_point);
+                if (!is_inside)
                     inside_dist = 0;
             }
         }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4750,6 +4750,7 @@ void GCodeGenerator::seam_notch(const ExtrusionLoop& original_loop,
 }
 
 static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
+        const Polygon* fallback_poly,
         bool is_hole_loop, bool is_full_loop_ccw,
         double nozzle_diam, double setting_max_depth,
         Point *inside_pt = nullptr)
@@ -4769,6 +4770,9 @@ static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
     if (idx >= 0) {
         next_point = poly.points[(idx + 1) % poly.points.size()];
         prev_point = poly.points[(idx + poly.points.size() - 1) % poly.points.size()];
+    } else if (fallback_poly != nullptr && (idx = fallback_poly->find_point(current_point, SCALED_EPSILON)) >= 0) {
+        next_point = fallback_poly->points[(idx + 1) % fallback_poly->points.size()];
+        prev_point = fallback_poly->points[(idx + fallback_poly->points.size() - 1) % fallback_poly->points.size()];
     } else {
         next_point = paths.front().polyline.get_point(1);
         prev_point = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
@@ -4806,7 +4810,7 @@ static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
     return dist;
 }
 
-void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
+void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
 {
     if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty() || paths.front().size() < 2)
         return;
@@ -4823,6 +4827,9 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_
     if (idx >= 0) {
         next_point = poly.points[(idx + 1) % poly.points.size()];
         prev_point = poly.points[(idx + poly.points.size() - 1) % poly.points.size()];
+    } else if (fallback_poly != nullptr && (idx = fallback_poly->find_point(current_point, SCALED_EPSILON)) >= 0) {
+        next_point = fallback_poly->points[(idx + 1) % fallback_poly->points.size()];
+        prev_point = fallback_poly->points[(idx + fallback_poly->points.size() - 1) % fallback_poly->points.size()];
     } else {
         next_point = paths.front().polyline.get_point(1);
         prev_point = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
@@ -4866,7 +4873,7 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_
                                                 m_current_instance_idx);
 }
 
-void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
+void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
 {
     if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty() || paths.back().size() < 2)
         return;
@@ -4883,6 +4890,9 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_lo
     if (idx >= 0) {
         prev_point = poly.points[(idx + poly.points.size() - 1) % poly.points.size()];
         next_point = poly.points[(idx + 1) % poly.points.size()];
+    } else if (fallback_poly != nullptr && (idx = fallback_poly->find_point(current_point, SCALED_EPSILON)) >= 0) {
+        prev_point = fallback_poly->points[(idx + fallback_poly->points.size() - 1) % fallback_poly->points.size()];
+        next_point = fallback_poly->points[(idx + 1) % fallback_poly->points.size()];
     } else {
         prev_point = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
         next_point = paths.front().polyline.get_point(1);
@@ -5071,7 +5081,8 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     bool inside_setting = BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside);
     if (inside_setting && original_loop.role().is_perimeter() && !is_hole_loop && !building_paths.empty()) {
         const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
-        inside_dist = compute_inside_distance_start(building_paths, is_hole_loop, is_full_loop_ccw,
+        inside_dist = compute_inside_distance_start(building_paths, &original_loop.polygon(),
+                                                   is_hole_loop, is_full_loop_ccw,
                                                    nozzle_diam, setting_max_depth, &inside_point);
         coordf_t threshold = coordf_t(scale_t(setting_max_depth)) / 4;
         bool cross_solid = false;
@@ -5144,7 +5155,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     assert(point_dist_for_vec > 0);
 
     if (apply_inside)
-        perimeter_inside_start(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
+        perimeter_inside_start(building_paths, &original_loop.polygon(), is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
 
     // generate the unretracting/wipe start move (same thing than for the end, but on the other side)
     assert(!wipe_paths.empty() && wipe_paths.front().size() > 1 && !wipe_paths.back().empty());
@@ -5237,7 +5248,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     }
 
     if (apply_inside)
-        perimeter_inside_end(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
+        perimeter_inside_end(building_paths, &original_loop.polygon(), is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
 
     // print seam tag with seam position (only for external perimeter & overhangs)
     if (original_loop.paths.front().role().is_external_perimeter())

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4838,28 +4838,6 @@ static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
     return dist;
 }
 
-coordf_t GCodeGenerator::limit_by_island(const Point& start, const Vec2d& normal, coordf_t dist) const
-{
-    if (m_current_island_polygons.empty() || dist <= 0)
-        return dist;
-
-    Point end = Point::round(start.cast<double>() + normal * dist);
-    Line  line(start, end);
-    double min_dist = dist;
-    for (const ExPolygon &ep : m_current_island_polygons) {
-        Points pts;
-        ep.contour.intersections(line, &pts);
-        for (const Polygon &h : ep.holes)
-            h.intersections(line, &pts);
-        for (const Point &ip : pts) {
-            double d = (ip.cast<double>() - start.cast<double>()).norm();
-            if (d > scaled<double>(0.0015) && d < min_dist)
-                min_dist = d;
-        }
-    }
-    return coordf_t(min_dist);
-}
-
 void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
 {
     if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty())

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5121,7 +5121,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         inside_dist = compute_inside_distance_start(building_paths, &loop_polygon,
                                                    is_hole_loop, is_full_loop_ccw,
                                                    nozzle_diam, setting_max_depth, &inside_point);
-        coordf_t threshold = coordf_t(scale_t(setting_max_depth)) / 4;
+        coordf_t threshold = scale_d(setting_max_depth) / 4;
         bool cross_solid = false;
         if (!m_layer_solid_surfaces.empty()) {
             for (const ExPolygon &ep : m_layer_solid_surfaces) {

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4860,6 +4860,16 @@ coordf_t GCodeGenerator::limit_by_island(const Point& start, const Vec2d& normal
     return coordf_t(min_dist);
 }
 
+bool GCodeGenerator::line_inside_island(const Line& line) const
+{
+    if (m_current_island_polygons.empty())
+        return true;
+    for (const ExPolygon &ep : m_current_island_polygons)
+        if (ep.contains(line))
+            return true;
+    return false;
+}
+
 void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
 {
     if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty())
@@ -4934,6 +4944,9 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon
     }
     dist = limit_by_island(current_point, normal, dist);
     Point pt = Point::round(current_pos + normal * dist);
+
+    if (!line_inside_island(Line(current_point, pt)))
+        return;
 
     ExtrusionPath inside_path(ArcPolyline(Polyline{ pt, current_point }), paths.front().attributes(), false);
     inside_path.attributes_mutable().mm3_per_mm = paths.front().mm3_per_mm() * 0.9;
@@ -5019,6 +5032,9 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, const Polygon* 
     }
     dist = limit_by_island(current_point, normal, dist);
     Point pt_inside = Point::round(current_pos + normal * dist);
+
+    if (!line_inside_island(Line(current_point, pt_inside)))
+        return;
 
     ExtrusionPath inside_path(ArcPolyline(Polyline{ current_point, pt_inside }), paths.back().attributes(), false);
     inside_path.attributes_mutable().mm3_per_mm = paths.back().mm3_per_mm() * 0.9;
@@ -5184,6 +5200,8 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
                 normal_vec /= len;
                 inside_dist = limit_by_island(building_paths.front().first_point(), normal_vec, inside_dist);
                 inside_point = Point::round(building_paths.front().first_point().cast<double>() + normal_vec * inside_dist);
+                if (!line_inside_island(Line(building_paths.front().first_point(), inside_point)))
+                    inside_dist = 0;
             }
         }
         coordf_t threshold = scale_d(nozzle_diam) * 2;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4001,9 +4001,6 @@ std::string GCodeGenerator::preamble()
 
 // called by GCodeGenerator::process_layer()
 std::string GCodeGenerator::change_layer(double print_z) {
-    // Store seam positions from the previous layer and start collecting new ones
-    m_last_seam_positions.swap(m_curr_seam_positions);
-    m_curr_seam_positions.clear();
 
     std::string gcode;
     if (layer_count() > 0)
@@ -4054,9 +4051,9 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
     //no! this was decided in perimeter_generator
     bool is_hole_loop = (loop_to_seam.loop_role() & ExtrusionLoopRole::elrHole) != 0;// loop.make_counter_clockwise();
     bool reverse_turn = loop_to_seam.polygon().is_clockwise() ^ is_hole_loop;
-    size_t perimeter_idx = m_curr_seam_positions.size();
+    size_t perimeter_idx = m_perimeter_index;
 
-    split_at_seam_pos(loop_to_seam, reverse_turn, perimeter_idx);
+    split_at_seam_pos(loop_to_seam, reverse_turn);
     Point seam_pos = loop_to_seam.first_point();
     const coordf_t full_loop_length = loop_to_seam.length();
 
@@ -4307,14 +4304,14 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
     }
 
     if ((original_loop.role().is_perimeter() || original_loop.role().is_mixed()) && !is_hole_loop)
-        m_curr_seam_positions.push_back(seam_pos);
+        ++m_perimeter_index;
 
     assert(!this->visitor_flipped);
     this->visitor_flipped = save_flipped;
     return gcode;
 }
 
-void GCodeGenerator::split_at_seam_pos(ExtrusionLoop& loop, bool was_clockwise, size_t perimeter_idx)
+void GCodeGenerator::split_at_seam_pos(ExtrusionLoop& loop, bool was_clockwise)
 {
     if (loop.paths.empty())
         return;
@@ -4367,23 +4364,7 @@ void GCodeGenerator::split_at_seam_pos(ExtrusionLoop& loop, bool was_clockwise, 
             //m_print_object_instance_id,
             //lower_layer_edge_grid ? lower_layer_edge_grid->get() : nullptr
             );
-        if (perimeter_idx < m_last_seam_positions.size()) {
-            coord_t nozzle = scale_(EXTRUDER_CONFIG_WITH_DEFAULT(nozzle_diameter, 0.4));
-            if (nozzle > 0) {
-                coord_t max_jump = nozzle * 5;
-                coord_t max_delta = nozzle / 8;
-                const Point &prev = m_last_seam_positions[perimeter_idx];
-                coord_t dist = seam_point.distance_to(prev);
-                if (dist <= max_jump) {
-                    if (dist > max_delta) {
-                        Vec2d move = (seam_point.cast<double>() - prev.cast<double>()).normalized() * unscaled<double>(max_delta);
-                        seam_point = Point::round(prev.cast<double>() + move);
-                    } else {
-                        seam_point = prev;
-                    }
-                }
-            }
-        }
+
         // Because the G-code export has 1um resolution, don't generate segments shorter than "1.5 microns" (depends of gcode_precision_xyz)
         //FIXME use settings
         if (!loop.split_at_vertex(seam_point, scaled<double>(0.0015))) {
@@ -5099,8 +5080,8 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         for (int i = 1; i < path.polyline.size(); ++i)
             assert(!path.polyline.get_point(i - 1).coincides_with_epsilon(path.polyline.get_point(i)));
 
-    size_t perimeter_idx = m_curr_seam_positions.size();
-    split_at_seam_pos(loop_to_seam, is_hole_loop, perimeter_idx);
+    size_t perimeter_idx = m_perimeter_index;
+    split_at_seam_pos(loop_to_seam, is_hole_loop);
     const Point seam_pos = loop_to_seam.first_point();
     const coordf_t full_loop_length = loop_to_seam.length();
     const bool is_full_loop_ccw = loop_to_seam.polygon().is_counter_clockwise();
@@ -5696,7 +5677,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         }
     }
     if ((original_loop.role().is_perimeter() || original_loop.role().is_mixed()) && !is_hole_loop)
-        m_curr_seam_positions.push_back(seam_pos);
+        ++m_perimeter_index;
 stop_print_loop:
 
     assert(!this->visitor_flipped);
@@ -6111,8 +6092,7 @@ void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const Lay
 {
     m_seam_perimeters = true;
     m_apply_inside_layer = false;
-    if (layer()->id() == 0)
-        m_last_seam_positions.clear();
+    m_perimeter_index = 0;
     m_current_object_layer_idx = print_args.print_instance.object_layer_to_print_id;
     m_current_instance_idx     = print_args.print_instance.instance_id;
     m_layer_solid_surfaces.clear();

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -40,6 +40,7 @@
 #include "Point.hpp"
 #include "Polygon.hpp"
 #include "Surface.hpp"
+#include "ExPolygon.hpp"
 #include "Geometry.hpp"
 #include "PrintConfig.hpp"
 #include "ShortestPath.hpp"

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4786,9 +4786,18 @@ static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
 
     Vec2d current_pos = current_point.cast<double>();
 
-    Vec2d tangent = (next_point.cast<double>() - current_point.cast<double>());
-    if (tangent.norm() == 0)
-        tangent = (current_point.cast<double>() - prev_point.cast<double>());
+    Vec2d vec_start = next_point.cast<double>() - current_point.cast<double>();
+    Vec2d vec_end   = current_point.cast<double>() - prev_point.cast<double>();
+    if (vec_start.norm() == 0)
+        vec_start = vec_end;
+    if (vec_end.norm() == 0)
+        vec_end = vec_start;
+    Vec2d tangent = vec_start;
+    if (vec_start.norm() != 0 && vec_end.norm() != 0) {
+        vec_start.normalize();
+        vec_end.normalize();
+        tangent = (vec_start + vec_end) / 2.0;
+    }
     if (tangent.norm() != 0)
         tangent.normalize();
 
@@ -4855,9 +4864,18 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon
 
     Vec2d current_pos = current_point.cast<double>();
 
-    Vec2d tangent = (next_point.cast<double>() - current_point.cast<double>());
-    if (tangent.norm() == 0)
-        tangent = (current_point.cast<double>() - prev_point.cast<double>());
+    Vec2d vec_start = next_point.cast<double>() - current_point.cast<double>();
+    Vec2d vec_end   = current_point.cast<double>() - prev_point.cast<double>();
+    if (vec_start.norm() == 0)
+        vec_start = vec_end;
+    if (vec_end.norm() == 0)
+        vec_end = vec_start;
+    Vec2d tangent = vec_start;
+    if (vec_start.norm() != 0 && vec_end.norm() != 0) {
+        vec_start.normalize();
+        vec_end.normalize();
+        tangent = (vec_start + vec_end) / 2.0;
+    }
     if (tangent.norm() != 0)
         tangent.normalize();
 
@@ -4930,9 +4948,18 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, const Polygon* 
 
     Vec2d current_pos = current_point.cast<double>();
 
-    Vec2d tangent = (current_point.cast<double>() - prev_point.cast<double>());
-    if (tangent.norm() == 0)
-        tangent = (next_point.cast<double>() - current_point.cast<double>());
+    Vec2d vec_end   = current_point.cast<double>() - prev_point.cast<double>();
+    Vec2d vec_start = next_point.cast<double>() - current_point.cast<double>();
+    if (vec_start.norm() == 0)
+        vec_start = vec_end;
+    if (vec_end.norm() == 0)
+        vec_end = vec_start;
+    Vec2d tangent = vec_end;
+    if (vec_start.norm() != 0 && vec_end.norm() != 0) {
+        vec_start.normalize();
+        vec_end.normalize();
+        tangent = (vec_start + vec_end) / 2.0;
+    }
     if (tangent.norm() != 0)
         tangent.normalize();
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5074,7 +5074,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         inside_dist = compute_inside_distance_start(building_paths, is_hole_loop, is_full_loop_ccw,
                                                    nozzle_diam, setting_max_depth, &inside_point);
         coordf_t threshold = coordf_t(scale_t(setting_max_depth)) / 4;
-        bool cross_solid = !m_layer_solid_surfaces.empty() && contains(m_layer_solid_surfaces, inside_point);
+        bool cross_solid = !m_layer_solid_surfaces.empty() && Geometry::contains(m_layer_solid_surfaces, inside_point);
         if (inside_dist >= threshold && !cross_solid)
             m_apply_inside_layer = true;
         apply_inside = m_apply_inside_layer && !cross_solid;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -39,6 +39,8 @@
 #include "GCode/Travels.hpp"
 #include "Point.hpp"
 #include "Polygon.hpp"
+#include "Surface.hpp"
+#include "Geometry.hpp"
 #include "PrintConfig.hpp"
 #include "ShortestPath.hpp"
 #include "PrintConfig.hpp"
@@ -4748,7 +4750,8 @@ void GCodeGenerator::seam_notch(const ExtrusionLoop& original_loop,
 
 static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
         bool is_hole_loop, bool is_full_loop_ccw,
-        double nozzle_diam, double setting_max_depth)
+        double nozzle_diam, double setting_max_depth,
+        Point *inside_pt = nullptr)
 {
     if (paths.empty() || paths.front().size() < 2 || paths.back().size() < 2)
         return 0;
@@ -4797,6 +4800,8 @@ static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
             }));
     if (dist <= 0)
         dist = scale_d(nozzle_diam) / 2;
+    if (inside_pt != nullptr)
+        *inside_pt = Point::round(current_pos + normal * dist);
     return dist;
 }
 
@@ -5061,15 +5066,17 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     }
     bool apply_inside = false;
     coordf_t inside_dist = 0;
+    Point     inside_point;
     bool inside_setting = BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside);
     if (inside_setting && original_loop.role().is_perimeter() && !is_hole_loop && !building_paths.empty()) {
         const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
         inside_dist = compute_inside_distance_start(building_paths, is_hole_loop, is_full_loop_ccw,
-                                                   nozzle_diam, setting_max_depth);
+                                                   nozzle_diam, setting_max_depth, &inside_point);
         coordf_t threshold = coordf_t(scale_t(setting_max_depth)) / 4;
-        if (inside_dist >= threshold)
+        bool cross_solid = !m_layer_solid_surfaces.empty() && contains(m_layer_solid_surfaces, inside_point);
+        if (inside_dist >= threshold && !cross_solid)
             m_apply_inside_layer = true;
-        apply_inside = m_apply_inside_layer || inside_dist >= threshold;
+        apply_inside = m_apply_inside_layer && !cross_solid;
     }
     if (apply_inside) {
         // For multiple perimeters, offset each loop start/end progressively so
@@ -5990,6 +5997,17 @@ void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const Lay
     m_apply_inside_layer = false;
     m_current_object_layer_idx = print_args.print_instance.object_layer_to_print_id;
     m_current_instance_idx     = print_args.print_instance.instance_id;
+    m_layer_solid_surfaces.clear();
+    for (const LayerRegion *lr : layer()->regions()) {
+        for (const Surface &srf : lr->fill_surfaces().surfaces) {
+            if ((srf.surface_type & SurfaceType::stPosTop) != 0 ||
+                (srf.surface_type & SurfaceType::stPosBottom) != 0 ||
+                (srf.surface_type & SurfaceType::stDensSolid) != 0)
+                m_layer_solid_surfaces.push_back(srf.expolygon);
+        }
+    }
+    if (!m_layer_solid_surfaces.empty())
+        m_layer_solid_surfaces = union_ex(m_layer_solid_surfaces);
     const LayerRegion &layerm = *layer()->get_region(island.perimeters.region());
     // PrintObjects own the PrintRegions, thus the pointer to PrintRegion would be unique to a PrintObject, they would not
     // identify the content of PrintRegion accross the whole print uniquely. Translate to a Print specific PrintRegion.
@@ -6044,6 +6062,7 @@ void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const Lay
     m_apply_inside_layer = false;
     m_current_object_layer_idx = 0;
     m_current_instance_idx = 0;
+    m_layer_solid_surfaces.clear();
 }
 
 // Chain the paths hierarchically by a greedy algorithm to minimize a travel distance.

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4864,8 +4864,11 @@ bool GCodeGenerator::line_inside_island(const Line& line) const
 {
     if (m_current_island_polygons.empty())
         return true;
+    // The generic ExPolygon::contains(Line) may fail when the line starts or
+    // ends on the polygon boundary. Test the end points explicitly and rely on
+    // limit_by_island() to avoid crossing island borders.
     for (const ExPolygon &ep : m_current_island_polygons)
-        if (ep.contains(line))
+        if (ep.contains(line.a, true) && ep.contains(line.b, true))
             return true;
     return false;
 }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4001,6 +4001,10 @@ std::string GCodeGenerator::preamble()
 
 // called by GCodeGenerator::process_layer()
 std::string GCodeGenerator::change_layer(double print_z) {
+    // Store seam positions from the previous layer and start collecting new ones
+    m_last_seam_positions.swap(m_curr_seam_positions);
+    m_curr_seam_positions.clear();
+
     std::string gcode;
     if (layer_count() > 0)
         // Increment a progress bar indicator.
@@ -4050,8 +4054,9 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
     //no! this was decided in perimeter_generator
     bool is_hole_loop = (loop_to_seam.loop_role() & ExtrusionLoopRole::elrHole) != 0;// loop.make_counter_clockwise();
     bool reverse_turn = loop_to_seam.polygon().is_clockwise() ^ is_hole_loop;
+    size_t perimeter_idx = m_curr_seam_positions.size();
 
-    split_at_seam_pos(loop_to_seam, reverse_turn, m_perimeter_index);
+    split_at_seam_pos(loop_to_seam, reverse_turn, perimeter_idx);
     Point seam_pos = loop_to_seam.first_point();
     const coordf_t full_loop_length = loop_to_seam.length();
 
@@ -4301,10 +4306,8 @@ std::string GCodeGenerator::extrude_loop_vase(const ExtrusionLoop &original_loop
         gcode += m_writer.travel_to_xy(this->point_to_gcode(inward_point), 0.0, "move inwards before travel");
     }
 
-    if (m_last_seam_positions.size() <= m_perimeter_index)
-        m_last_seam_positions.resize(m_perimeter_index + 1);
-    m_last_seam_positions[m_perimeter_index] = seam_pos;
-    ++m_perimeter_index;
+    if ((original_loop.role().is_perimeter() || original_loop.role().is_mixed()) && !is_hole_loop)
+        m_curr_seam_positions.push_back(seam_pos);
 
     assert(!this->visitor_flipped);
     this->visitor_flipped = save_flipped;
@@ -5096,11 +5099,11 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         for (int i = 1; i < path.polyline.size(); ++i)
             assert(!path.polyline.get_point(i - 1).coincides_with_epsilon(path.polyline.get_point(i)));
 
-    split_at_seam_pos(loop_to_seam, is_hole_loop, m_perimeter_index);
+    size_t perimeter_idx = m_curr_seam_positions.size();
+    split_at_seam_pos(loop_to_seam, is_hole_loop, perimeter_idx);
     const Point seam_pos = loop_to_seam.first_point();
     const coordf_t full_loop_length = loop_to_seam.length();
     const bool is_full_loop_ccw = loop_to_seam.polygon().is_counter_clockwise();
-    size_t perimeter_idx = m_perimeter_index;
     //after that point, loop_to_seam can be modified by 'paths', so don't use it anymore
 #ifdef _DEBUG
     for (auto it = std::next(loop_to_seam.paths.begin()); it != loop_to_seam.paths.end(); ++it) {
@@ -5692,12 +5695,8 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Wipe_End) + "\n";
         }
     }
-    if ((original_loop.role().is_perimeter() || original_loop.role().is_mixed()) && !is_hole_loop) {
-        if (m_last_seam_positions.size() <= perimeter_idx)
-            m_last_seam_positions.resize(perimeter_idx + 1);
-        m_last_seam_positions[perimeter_idx] = seam_pos;
-        ++m_perimeter_index;
-    }
+    if ((original_loop.role().is_perimeter() || original_loop.role().is_mixed()) && !is_hole_loop)
+        m_curr_seam_positions.push_back(seam_pos);
 stop_print_loop:
 
     assert(!this->visitor_flipped);
@@ -6111,7 +6110,6 @@ void GCodeGenerator::set_region_for_extrude(const Print &print, const PrintObjec
 void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const LayerIsland &island, std::string &gcode)
 {
     m_seam_perimeters = true;
-    m_perimeter_index = 0;
     m_apply_inside_layer = false;
     if (layer()->id() == 0)
         m_last_seam_positions.clear();

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4798,11 +4798,24 @@ static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
     normal.normalize();
 
     coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
-    if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
+    if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55) {
         dist = coordf_t(check_wipe::max_depth(paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
             [current_pos, normal](coord_t d)->Point {
                 return Point::round(current_pos + normal * d);
             }));
+        if (fallback_poly != nullptr && dist <= scale_d(nozzle_diam) / 2) {
+            ExtrusionPaths tmp_paths;
+            tmp_paths.emplace_back(paths.front());
+            tmp_paths.back().polyline.clear();
+            tmp_paths.back().polyline.append(fallback_poly->points.begin(), fallback_poly->points.end());
+            tmp_paths.back().polyline.append(fallback_poly->points.front());
+            coordf_t dist_poly = coordf_t(check_wipe::max_depth(tmp_paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
+                [current_pos, normal](coord_t d)->Point {
+                    return Point::round(current_pos + normal * d);
+                }));
+            dist = std::max(dist, dist_poly);
+        }
+    }
     if (dist <= 0)
         dist = scale_d(nozzle_diam) / 2;
     if (inside_pt != nullptr)
@@ -4856,11 +4869,24 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon
 
     const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
     coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
-    if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
+    if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55) {
         dist = coordf_t(check_wipe::max_depth(paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
             [current_pos, normal](coord_t dist)->Point {
                 return Point::round(current_pos + normal * dist);
             }));
+        if (fallback_poly != nullptr && dist <= scale_d(nozzle_diam) / 2) {
+            ExtrusionPaths tmp_paths;
+            tmp_paths.emplace_back(paths.front());
+            tmp_paths.back().polyline.clear();
+            tmp_paths.back().polyline.append(fallback_poly->points.begin(), fallback_poly->points.end());
+            tmp_paths.back().polyline.append(fallback_poly->points.front());
+            coordf_t dist_poly = coordf_t(check_wipe::max_depth(tmp_paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
+                [current_pos, normal](coord_t dist)->Point {
+                    return Point::round(current_pos + normal * dist);
+                }));
+            dist = std::max(dist, dist_poly);
+        }
+    }
     Point pt = Point::round(current_pos + normal * dist);
 
     ExtrusionPath inside_path(ArcPolyline(Polyline{ pt, current_point }), paths.front().attributes(), false);
@@ -4919,11 +4945,24 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, const Polygon* 
 
     const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
     coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
-    if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
+    if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55) {
         dist = coordf_t(check_wipe::max_depth(paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
             [current_pos, normal](coord_t dist)->Point {
                 return Point::round(current_pos + normal * dist);
             }));
+        if (fallback_poly != nullptr && dist <= scale_d(nozzle_diam) / 2) {
+            ExtrusionPaths tmp_paths;
+            tmp_paths.emplace_back(paths.front());
+            tmp_paths.back().polyline.clear();
+            tmp_paths.back().polyline.append(fallback_poly->points.begin(), fallback_poly->points.end());
+            tmp_paths.back().polyline.append(fallback_poly->points.front());
+            coordf_t dist_poly = coordf_t(check_wipe::max_depth(tmp_paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
+                [current_pos, normal](coord_t dist)->Point {
+                    return Point::round(current_pos + normal * dist);
+                }));
+            dist = std::max(dist, dist_poly);
+        }
+    }
     Point pt_inside = Point::round(current_pos + normal * dist);
 
     ExtrusionPath inside_path(ArcPolyline(Polyline{ current_point, pt_inside }), paths.back().attributes(), false);

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5074,7 +5074,15 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         inside_dist = compute_inside_distance_start(building_paths, is_hole_loop, is_full_loop_ccw,
                                                    nozzle_diam, setting_max_depth, &inside_point);
         coordf_t threshold = coordf_t(scale_t(setting_max_depth)) / 4;
-        bool cross_solid = !m_layer_solid_surfaces.empty() && Geometry::contains(m_layer_solid_surfaces, inside_point);
+        bool cross_solid = false;
+        if (!m_layer_solid_surfaces.empty()) {
+            for (const ExPolygon &ep : m_layer_solid_surfaces) {
+                if (ep.contains(inside_point, false)) {
+                    cross_solid = true;
+                    break;
+                }
+            }
+        }
         if (inside_dist >= threshold && !cross_solid)
             m_apply_inside_layer = true;
         apply_inside = m_apply_inside_layer && !cross_solid;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5081,7 +5081,8 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     bool inside_setting = BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside);
     if (inside_setting && original_loop.role().is_perimeter() && !is_hole_loop && !building_paths.empty()) {
         const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
-        inside_dist = compute_inside_distance_start(building_paths, &original_loop.polygon(),
+        Polygon loop_polygon = original_loop.polygon();
+        inside_dist = compute_inside_distance_start(building_paths, &loop_polygon,
                                                    is_hole_loop, is_full_loop_ccw,
                                                    nozzle_diam, setting_max_depth, &inside_point);
         coordf_t threshold = coordf_t(scale_t(setting_max_depth)) / 4;
@@ -5154,8 +5155,10 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     coordf_t point_dist_for_vec = std::max(scale_t(nozzle_diam) / 100, scale_t(m_config.seam_gap.get_abs_value(m_writer.tool()->id(), nozzle_diam)) / 2);
     assert(point_dist_for_vec > 0);
 
-    if (apply_inside)
-        perimeter_inside_start(building_paths, &original_loop.polygon(), is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
+    if (apply_inside) {
+        Polygon loop_polygon = original_loop.polygon();
+        perimeter_inside_start(building_paths, &loop_polygon, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
+    }
 
     // generate the unretracting/wipe start move (same thing than for the end, but on the other side)
     assert(!wipe_paths.empty() && wipe_paths.front().size() > 1 && !wipe_paths.back().empty());
@@ -5247,8 +5250,10 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         gcode += extrude_path(path, description, speed);
     }
 
-    if (apply_inside)
-        perimeter_inside_end(building_paths, &original_loop.polygon(), is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
+    if (apply_inside) {
+        Polygon loop_polygon = original_loop.polygon();
+        perimeter_inside_end(building_paths, &loop_polygon, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
+    }
 
     // print seam tag with seam position (only for external perimeter & overhangs)
     if (original_loop.paths.front().role().is_external_perimeter())

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4838,6 +4838,28 @@ static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
     return dist;
 }
 
+coordf_t GCodeGenerator::limit_by_island(const Point& start, const Vec2d& normal, coordf_t dist) const
+{
+    if (m_current_island_polygons.empty() || dist <= 0)
+        return dist;
+
+    Point end = Point::round(start.cast<double>() + normal * dist);
+    Line  line(start, end);
+    double min_dist = dist;
+    for (const ExPolygon &ep : m_current_island_polygons) {
+        Points pts;
+        ep.contour.intersections(line, &pts);
+        for (const Polygon &h : ep.holes)
+            h.intersections(line, &pts);
+        for (const Point &ip : pts) {
+            double d = (ip.cast<double>() - start.cast<double>()).norm();
+            if (d > scaled<double>(0.0015) && d < min_dist)
+                min_dist = d;
+        }
+    }
+    return coordf_t(min_dist);
+}
+
 void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
 {
     if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty())
@@ -4910,6 +4932,7 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon
             dist = std::max(dist, dist_poly);
         }
     }
+    dist = limit_by_island(current_point, normal, dist);
     Point pt = Point::round(current_pos + normal * dist);
 
     ExtrusionPath inside_path(ArcPolyline(Polyline{ pt, current_point }), paths.front().attributes(), false);
@@ -4994,6 +5017,7 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, const Polygon* 
             dist = std::max(dist, dist_poly);
         }
     }
+    dist = limit_by_island(current_point, normal, dist);
     Point pt_inside = Point::round(current_pos + normal * dist);
 
     ExtrusionPath inside_path(ArcPolyline(Polyline{ current_point, pt_inside }), paths.back().attributes(), false);
@@ -5153,6 +5177,15 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         inside_dist = compute_inside_distance_start(building_paths, &loop_polygon,
                                                    is_hole_loop, is_full_loop_ccw,
                                                    nozzle_diam, setting_max_depth, &inside_point);
+        if (inside_dist > 0) {
+            Vec2d normal_vec = (inside_point.cast<double>() - building_paths.front().first_point().cast<double>());
+            double len = normal_vec.norm();
+            if (len > 0) {
+                normal_vec /= len;
+                inside_dist = limit_by_island(building_paths.front().first_point(), normal_vec, inside_dist);
+                inside_point = Point::round(building_paths.front().first_point().cast<double>() + normal_vec * inside_dist);
+            }
+        }
         coordf_t threshold = scale_d(nozzle_diam) * 2;
         bool cross_solid = false;
         if (!m_layer_solid_surfaces.empty()) {
@@ -6096,6 +6129,7 @@ void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const Lay
     m_current_object_layer_idx = print_args.print_instance.object_layer_to_print_id;
     m_current_instance_idx     = print_args.print_instance.instance_id;
     m_layer_solid_surfaces.clear();
+    m_current_island_polygons.clear();
     for (const LayerRegion *lr : layer()->regions()) {
         for (const Surface &srf : lr->fill_surfaces().surfaces) {
             if ((srf.surface_type & SurfaceType::stPosTop) != 0 ||
@@ -6106,6 +6140,14 @@ void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const Lay
     }
     if (!m_layer_solid_surfaces.empty())
         m_layer_solid_surfaces = union_ex(m_layer_solid_surfaces);
+    if (!island.fill_expolygons.empty()) {
+        const LayerRegion &fill_lr = *layer()->get_region(island.fill_expolygons_composite() ?
+            island.perimeters.region() : island.fill_region_id);
+        const ExPolygons &expolys = island.fill_expolygons_composite() ?
+            fill_lr.fill_expolygons_composite() : fill_lr.fill_expolygons();
+        for (uint32_t id : island.fill_expolygons)
+            m_current_island_polygons.push_back(expolys[id]);
+    }
     const LayerRegion &layerm = *layer()->get_region(island.perimeters.region());
     // PrintObjects own the PrintRegions, thus the pointer to PrintRegion would be unique to a PrintObject, they would not
     // identify the content of PrintRegion accross the whole print uniquely. Translate to a Print specific PrintRegion.
@@ -6161,6 +6203,7 @@ void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const Lay
     m_current_object_layer_idx = 0;
     m_current_instance_idx = 0;
     m_layer_solid_surfaces.clear();
+    m_current_island_polygons.clear();
 }
 
 // Chain the paths hierarchically by a greedy algorithm to minimize a travel distance.

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5051,7 +5051,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     const coordf_t full_loop_length = loop_to_seam.length();
     const bool is_full_loop_ccw = loop_to_seam.polygon().is_counter_clockwise();
     size_t perimeter_idx = 0;
-    if (original_loop.role().is_perimeter() && !is_hole_loop)
+    if ((original_loop.role().is_perimeter() || original_loop.role().is_mixed()) && !is_hole_loop)
         perimeter_idx = m_perimeter_index++;
     //after that point, loop_to_seam can be modified by 'paths', so don't use it anymore
 #ifdef _DEBUG
@@ -5115,7 +5115,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     coordf_t inside_dist = 0;
     Point     inside_point;
     bool inside_setting = BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside);
-    if (inside_setting && original_loop.role().is_perimeter() && !is_hole_loop && !building_paths.empty()) {
+    if (inside_setting && (original_loop.role().is_perimeter() || original_loop.role().is_mixed()) && !is_hole_loop && !building_paths.empty()) {
         const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
         Polygon loop_polygon = original_loop.polygon();
         inside_dist = compute_inside_distance_start(building_paths, &loop_polygon,

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -767,6 +767,8 @@ GCodeGenerator::GCodeGenerator() :
     m_second_layer_things_done(false),
     m_silent_time_estimator_enabled(false),
     m_current_instance({nullptr, -1}),
+    m_current_object_layer_idx(0),
+    m_current_instance_idx(0),
     m_last_too_small(ExtrusionPath{ExtrusionAttributes{ExtrusionRole::None}})
     {
         cooldown_marker_init();
@@ -4744,6 +4746,181 @@ void GCodeGenerator::seam_notch(const ExtrusionLoop& original_loop,
     for(auto &e : notch_extrusion_end) assert(e.polyline.empty() || e.polyline.is_valid());
 }
 
+static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
+        bool is_hole_loop, bool is_full_loop_ccw,
+        double nozzle_diam, double setting_max_depth)
+{
+    if (paths.empty() || paths.front().size() < 2 || paths.back().size() < 2)
+        return 0;
+
+    Point current_point = paths.front().first_point();
+    Polygon poly;
+    for (const ExtrusionPath &p : paths) {
+        Polyline pl = p.polyline.to_polyline();
+        poly.points.insert(poly.points.end(), pl.points.begin(), pl.points.end() - 1);
+    }
+    int idx = poly.find_point(current_point, SCALED_EPSILON);
+    Point next_point;
+    Point prev_point;
+    if (idx >= 0) {
+        next_point = poly.points[(idx + 1) % poly.points.size()];
+        prev_point = poly.points[(idx + poly.points.size() - 1) % poly.points.size()];
+    } else {
+        next_point = paths.front().polyline.get_point(1);
+        prev_point = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
+    }
+
+    Vec2d current_pos = current_point.cast<double>();
+
+    Vec2d dir_prev = (current_point.cast<double>() - prev_point.cast<double>());
+    Vec2d dir_next = (next_point.cast<double>() - current_point.cast<double>());
+    if (dir_prev.norm() == 0)
+        dir_prev = dir_next;
+    if (dir_next.norm() == 0)
+        dir_next = dir_prev;
+    dir_prev.normalize();
+    dir_next.normalize();
+    Vec2d tangent = dir_prev + dir_next;
+    if (tangent.squaredNorm() < 1e-12)
+        tangent = dir_next;
+    tangent.normalize();
+
+    double sign = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? 1. : -1.;
+    Vec2d normal(sign > 0 ? -tangent.y() : tangent.y(), sign > 0 ? tangent.x() : -tangent.x());
+    normal.normalize();
+
+    coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
+    if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
+        dist = coordf_t(check_wipe::max_depth(paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
+            [current_pos, normal](coord_t d)->Point {
+                return Point::round(current_pos + normal * d);
+            }));
+    if (dist <= 0)
+        dist = scale_d(nozzle_diam) / 2;
+    return dist;
+}
+
+void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
+{
+    if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty() || paths.front().size() < 2)
+        return;
+
+    Point current_point = paths.front().first_point();
+    Polygon poly;
+    for (const ExtrusionPath &p : paths) {
+        Polyline pl = p.polyline.to_polyline();
+        poly.points.insert(poly.points.end(), pl.points.begin(), pl.points.end() - 1);
+    }
+    int idx = poly.find_point(current_point, SCALED_EPSILON);
+    Point next_point;
+    Point prev_point;
+    if (idx >= 0) {
+        next_point = poly.points[(idx + 1) % poly.points.size()];
+        prev_point = poly.points[(idx + poly.points.size() - 1) % poly.points.size()];
+    } else {
+        next_point = paths.front().polyline.get_point(1);
+        prev_point = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
+    }
+
+    Vec2d current_pos = current_point.cast<double>();
+
+    Vec2d dir_prev = (current_point.cast<double>() - prev_point.cast<double>());
+    Vec2d dir_next = (next_point.cast<double>() - current_point.cast<double>());
+    if (dir_prev.norm() == 0)
+        dir_prev = dir_next;
+    if (dir_next.norm() == 0)
+        dir_next = dir_prev;
+    dir_prev.normalize();
+    dir_next.normalize();
+    Vec2d tangent = dir_prev + dir_next;
+    if (tangent.squaredNorm() < 1e-12)
+        tangent = dir_next;
+    tangent.normalize();
+
+    double sign = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? 1. : -1.;
+    Vec2d normal(sign > 0 ? -tangent.y() : tangent.y(), sign > 0 ? tangent.x() : -tangent.x());
+    normal.normalize();
+
+    const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
+    coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
+    if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
+        dist = coordf_t(check_wipe::max_depth(paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
+            [current_pos, normal](coord_t dist)->Point {
+                return Point::round(current_pos + normal * dist);
+            }));
+    Point pt = Point::round(current_pos + normal * dist);
+
+    ExtrusionPath inside_path(ArcPolyline(Polyline{ pt, current_point }), paths.front().attributes(), false);
+    inside_path.attributes_mutable().mm3_per_mm = paths.front().mm3_per_mm() * 0.9;
+    gcode += this->_travel_before_extrude(inside_path, "perimeter inside start", speed);
+    gcode += this->extrude_path(inside_path, "perimeter inside start", speed);
+    if (m_travel_obstacle_tracker.is_init())
+        m_travel_obstacle_tracker.mark_extruded(&inside_path,
+                                                m_current_object_layer_idx,
+                                                m_current_instance_idx);
+}
+
+void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
+{
+    if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty() || paths.back().size() < 2)
+        return;
+
+    Point current_point = paths.back().last_point();
+    Polygon poly;
+    for (const ExtrusionPath &p : paths) {
+        Polyline pl = p.polyline.to_polyline();
+        poly.points.insert(poly.points.end(), pl.points.begin(), pl.points.end() - 1);
+    }
+    int idx = poly.find_point(current_point, SCALED_EPSILON);
+    Point prev_point;
+    Point next_point;
+    if (idx >= 0) {
+        prev_point = poly.points[(idx + poly.points.size() - 1) % poly.points.size()];
+        next_point = poly.points[(idx + 1) % poly.points.size()];
+    } else {
+        prev_point = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
+        next_point = paths.front().polyline.get_point(1);
+    }
+
+    Vec2d current_pos = current_point.cast<double>();
+
+    Vec2d dir_prev = (current_point.cast<double>() - prev_point.cast<double>());
+    Vec2d dir_next = (next_point.cast<double>() - current_point.cast<double>());
+    if (dir_prev.norm() == 0)
+        dir_prev = dir_next;
+    if (dir_next.norm() == 0)
+        dir_next = dir_prev;
+    dir_prev.normalize();
+    dir_next.normalize();
+    Vec2d tangent = dir_prev + dir_next;
+    if (tangent.squaredNorm() < 1e-12)
+        tangent = dir_prev;
+    tangent.normalize();
+
+    double sign = (is_hole_loop ? (!is_full_loop_ccw) : (is_full_loop_ccw)) ? 1. : -1.;
+    Vec2d normal(sign > 0 ? -tangent.y() : tangent.y(), sign > 0 ? tangent.x() : -tangent.x());
+    normal.normalize();
+
+    const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
+    coordf_t dist = setting_max_depth <= 0 ? scale_d(nozzle_diam) / 2 : scale_d(setting_max_depth);
+    if (nozzle_diam != 0 && setting_max_depth > nozzle_diam * 0.55)
+        dist = coordf_t(check_wipe::max_depth(paths, scale_t(setting_max_depth), scale_t(nozzle_diam),
+            [current_pos, normal](coord_t dist)->Point {
+                return Point::round(current_pos + normal * dist);
+            }));
+    Point pt_inside = Point::round(current_pos + normal * dist);
+
+    ExtrusionPath inside_path(ArcPolyline(Polyline{ current_point, pt_inside }), paths.back().attributes(), false);
+    inside_path.attributes_mutable().mm3_per_mm = paths.back().mm3_per_mm() * 0.9;
+    gcode += this->_travel_before_extrude(inside_path, "perimeter inside end", speed);
+    gcode += this->extrude_path(inside_path, "perimeter inside end", speed);
+    if (m_travel_obstacle_tracker.is_init())
+        m_travel_obstacle_tracker.mark_extruded(&inside_path,
+                                                m_current_object_layer_idx,
+                                                m_current_instance_idx);
+    this->set_last_pos(pt_inside);
+}
+
 std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, const std::string_view description, double speed)
 {
     DEBUG_VISIT(original_loop, LoopAssertVisitor())
@@ -4821,6 +4998,9 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     const Point seam_pos = loop_to_seam.first_point();
     const coordf_t full_loop_length = loop_to_seam.length();
     const bool is_full_loop_ccw = loop_to_seam.polygon().is_counter_clockwise();
+    size_t perimeter_idx = 0;
+    if (original_loop.role().is_perimeter() && !is_hole_loop)
+        perimeter_idx = m_perimeter_index++;
     //after that point, loop_to_seam can be modified by 'paths', so don't use it anymore
 #ifdef _DEBUG
     for (auto it = std::next(loop_to_seam.paths.begin()); it != loop_to_seam.paths.end(); ++it) {
@@ -4879,6 +5059,33 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
             }
         }
     }
+    bool apply_inside = false;
+    coordf_t inside_dist = 0;
+    bool inside_setting = BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside);
+    if (inside_setting && original_loop.role().is_perimeter() && !is_hole_loop && !building_paths.empty()) {
+        const double setting_max_depth = m_config.extrude_perimeter_inside_length.get_at(m_writer.tool()->id());
+        inside_dist = compute_inside_distance_start(building_paths, is_hole_loop, is_full_loop_ccw,
+                                                   nozzle_diam, setting_max_depth);
+        coordf_t threshold = coordf_t(scale_t(setting_max_depth)) / 4;
+        if (inside_dist >= threshold)
+            m_apply_inside_layer = true;
+        apply_inside = m_apply_inside_layer || inside_dist >= threshold;
+    }
+    if (apply_inside) {
+        // For multiple perimeters, offset each loop start/end progressively so
+        // the inside segments do not overlap. The outermost perimeter uses half
+        // a perimeter width and each subsequent perimeter adds another half
+        // width.
+        double inset_factor = 0.5 * (perimeter_idx + 1);
+        coordf_t inset = scale_(building_paths.front().width() * inset_factor);
+        if (inset > 0 && inset < full_loop_length / 2) {
+            clip_start(building_paths, inset);
+            clip_end(building_paths, inset);
+        }
+    }
+    // When extruding a short path inside before and after the loop, do not
+    // modify the perimeter itself. The inside segments are tracked separately
+    // and the loop is printed in full so the configured length is preserved.
     if (building_paths.empty()) return "";
     if (building_paths.size() == 1)
         assert(is_full_loop_ccw == Polygon(building_paths.front().polyline.to_polyline().points).is_counter_clockwise());
@@ -4917,9 +5124,12 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
     coordf_t point_dist_for_vec = std::max(scale_t(nozzle_diam) / 100, scale_t(m_config.seam_gap.get_abs_value(m_writer.tool()->id(), nozzle_diam)) / 2);
     assert(point_dist_for_vec > 0);
 
+    if (apply_inside)
+        perimeter_inside_start(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
+
     // generate the unretracting/wipe start move (same thing than for the end, but on the other side)
     assert(!wipe_paths.empty() && wipe_paths.front().size() > 1 && !wipe_paths.back().empty());
-    if (EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_start, true) && !wipe_paths.empty() && wipe_paths.front().size() > 1 && wipe_paths.back().size() > 1 && wipe_paths.front().role().is_external_perimeter()) {
+    if (!apply_inside && EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_start, true) && !wipe_paths.empty() && wipe_paths.front().size() > 1 && wipe_paths.back().size() > 1 && wipe_paths.front().role().is_external_perimeter()) {
         //note: previous & next are inverted to extrude "in the opposite direction, as we are "rewinding"
         //Point previous_point = wipe_paths.back().polyline.points.back();
         Point previous_point = wipe_paths.front().polyline.get_point_from_begin(std::min(wipe_paths.front().polyline.length() / 2, point_dist_for_vec));
@@ -5006,6 +5216,9 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         assert(!path.can_reverse());
         gcode += extrude_path(path, description, speed);
     }
+
+    if (apply_inside)
+        perimeter_inside_end(building_paths, is_hole_loop, is_full_loop_ccw, nozzle_diam, gcode, speed);
 
     // print seam tag with seam position (only for external perimeter & overhangs)
     if (original_loop.paths.front().role().is_external_perimeter())
@@ -5164,7 +5377,7 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         Point pt_inside = Point::round(/*(nd >= vec_norm) ? next_pos : */ (current_pos + vec_dist * ( dist / (vec_norm * sin_a))));
         pt_inside.rotate(angle, current_point);
 
-        if (EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) {
+        if (!apply_inside && EXTRUDER_CONFIG_WITH_DEFAULT(wipe_inside_end, true)) {
             if (!m_wipe.is_enabled()) {
                 if (!start_wipe.empty()) {
                     gcode += start_wipe;
@@ -5773,6 +5986,10 @@ void GCodeGenerator::set_region_for_extrude(const Print &print, const PrintObjec
 void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const LayerIsland &island, std::string &gcode)
 {
     m_seam_perimeters = true;
+    m_perimeter_index = 0;
+    m_apply_inside_layer = false;
+    m_current_object_layer_idx = print_args.print_instance.object_layer_to_print_id;
+    m_current_instance_idx     = print_args.print_instance.instance_id;
     const LayerRegion &layerm = *layer()->get_region(island.perimeters.region());
     // PrintObjects own the PrintRegions, thus the pointer to PrintRegion would be unique to a PrintObject, they would not
     // identify the content of PrintRegion accross the whole print uniquely. Translate to a Print specific PrintRegion.
@@ -5824,6 +6041,9 @@ void GCodeGenerator::extrude_perimeters(const ExtrudeArgs &print_args, const Lay
     }
     m_region = nullptr;
     m_seam_perimeters = false;
+    m_apply_inside_layer = false;
+    m_current_object_layer_idx = 0;
+    m_current_instance_idx = 0;
 }
 
 // Chain the paths hierarchically by a greedy algorithm to minimize a travel distance.

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5079,11 +5079,14 @@ std::string GCodeGenerator::extrude_loop(const ExtrusionLoop &original_loop, con
         apply_inside = m_apply_inside_layer && !cross_solid;
     }
     if (apply_inside) {
-        // For multiple perimeters, offset each loop start/end progressively so
-        // the inside segments do not overlap. The outermost perimeter uses half
-        // a perimeter width and each subsequent perimeter adds another half
-        // width.
-        double inset_factor = 0.5 * (perimeter_idx + 1);
+        // Offset each loop start/end progressively so the inside segments do not
+        // overlap. The outermost perimeter shall only be clipped by half of its
+        // width regardless of the print order. Inner perimeters are clipped by
+        // multiples of half a width moving inwards.
+        size_t perims_cfg = m_region ? m_region->config().perimeters.value : 1;
+        bool   outer_first = m_region ? m_region->config().external_perimeters_first.value : true;
+        double inset_factor = 0.5 * (outer_first ? double(perimeter_idx + 1)
+                                                 : std::max(1.0, double(perims_cfg - perimeter_idx)));
         coordf_t inset = scale_(building_paths.front().width() * inset_factor);
         if (inset > 0 && inset < full_loop_length / 2) {
             clip_start(building_paths, inset);

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4774,8 +4774,14 @@ static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
         next_point = fallback_poly->points[(idx + 1) % fallback_poly->points.size()];
         prev_point = fallback_poly->points[(idx + fallback_poly->points.size() - 1) % fallback_poly->points.size()];
     } else {
-        next_point = paths.front().polyline.get_point(1);
-        prev_point = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
+        if (fallback_poly != nullptr && fallback_poly->size() >= 2) {
+            idx = fallback_poly->closest_point_index(current_point);
+            next_point = fallback_poly->points[(idx + 1) % fallback_poly->points.size()];
+            prev_point = fallback_poly->points[(idx + fallback_poly->points.size() - 1) % fallback_poly->points.size()];
+        } else {
+            next_point = paths.front().size() >= 2 ? paths.front().polyline.get_point(1) : current_point;
+            prev_point = paths.back().size() >= 2 ? paths.back().polyline.get_point(paths.back().polyline.size() - 2) : current_point;
+        }
     }
 
     Vec2d current_pos = current_point.cast<double>();
@@ -4825,7 +4831,7 @@ static coordf_t compute_inside_distance_start(const ExtrusionPaths& paths,
 
 void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
 {
-    if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty() || paths.front().size() < 2)
+    if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty())
         return;
 
     Point current_point = paths.front().first_point();
@@ -4844,8 +4850,14 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon
         next_point = fallback_poly->points[(idx + 1) % fallback_poly->points.size()];
         prev_point = fallback_poly->points[(idx + fallback_poly->points.size() - 1) % fallback_poly->points.size()];
     } else {
-        next_point = paths.front().polyline.get_point(1);
-        prev_point = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
+        if (fallback_poly != nullptr && fallback_poly->size() >= 2) {
+            idx = fallback_poly->closest_point_index(current_point);
+            next_point = fallback_poly->points[(idx + 1) % fallback_poly->points.size()];
+            prev_point = fallback_poly->points[(idx + fallback_poly->points.size() - 1) % fallback_poly->points.size()];
+        } else {
+            next_point = paths.front().size() >= 2 ? paths.front().polyline.get_point(1) : current_point;
+            prev_point = paths.back().size() >= 2 ? paths.back().polyline.get_point(paths.back().polyline.size() - 2) : current_point;
+        }
     }
 
     Vec2d current_pos = current_point.cast<double>();
@@ -4901,7 +4913,7 @@ void GCodeGenerator::perimeter_inside_start(ExtrusionPaths& paths, const Polygon
 
 void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed)
 {
-    if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty() || paths.back().size() < 2)
+    if (!BOOL_EXTRUDER_CONFIG(extrude_perimeter_inside) || is_hole_loop || paths.empty())
         return;
 
     Point current_point = paths.back().last_point();
@@ -4920,8 +4932,14 @@ void GCodeGenerator::perimeter_inside_end(ExtrusionPaths& paths, const Polygon* 
         prev_point = fallback_poly->points[(idx + fallback_poly->points.size() - 1) % fallback_poly->points.size()];
         next_point = fallback_poly->points[(idx + 1) % fallback_poly->points.size()];
     } else {
-        prev_point = paths.back().polyline.get_point(paths.back().polyline.size() - 2);
-        next_point = paths.front().polyline.get_point(1);
+        if (fallback_poly != nullptr && fallback_poly->size() >= 2) {
+            idx = fallback_poly->closest_point_index(current_point);
+            prev_point = fallback_poly->points[(idx + fallback_poly->points.size() - 1) % fallback_poly->points.size()];
+            next_point = fallback_poly->points[(idx + 1) % fallback_poly->points.size()];
+        } else {
+            prev_point = paths.back().size() >= 2 ? paths.back().polyline.get_point(paths.back().polyline.size() - 2) : current_point;
+            next_point = paths.front().size() >= 2 ? paths.front().polyline.get_point(1) : current_point;
+        }
     }
 
     Vec2d current_pos = current_point.cast<double>();

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -312,6 +312,7 @@ private:
         ExtrusionPaths& notch_extrusion_start, ExtrusionPaths& notch_extrusion_end, bool is_hole_loop, bool is_full_loop_ccw);
     void            perimeter_inside_start(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
     void            perimeter_inside_end(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
+    coordf_t        limit_by_island(const Point& start, const Vec2d& normal, coordf_t dist) const;
 
 
 	struct InstanceToPrint
@@ -480,6 +481,7 @@ private:
     size_t                              m_current_object_layer_idx{0};
     size_t                              m_current_instance_idx{0};
     ExPolygons                         m_layer_solid_surfaces;
+    ExPolygons                         m_current_island_polygons;
     // Current layer processed. In sequential printing mode, only a single copy will be printed.
     // In non-sequential mode, all its copies will be printed.
     const Layer*                        m_layer;

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -313,7 +313,6 @@ private:
     void            perimeter_inside_start(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
     void            perimeter_inside_end(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
     coordf_t        limit_by_island(const Point& start, const Vec2d& normal, coordf_t dist) const;
-    bool            line_inside_island(const Line& line) const;
 
 
 	struct InstanceToPrint

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -313,6 +313,7 @@ private:
     void            perimeter_inside_start(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
     void            perimeter_inside_end(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
     coordf_t        limit_by_island(const Point& start, const Vec2d& normal, coordf_t dist) const;
+    bool            line_inside_island(const Line& line) const;
 
 
 	struct InstanceToPrint

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -480,6 +480,7 @@ private:
     // Current object layer and instance index for obstacle tracking
     size_t                              m_current_object_layer_idx{0};
     size_t                              m_current_instance_idx{0};
+    ExPolygons                         m_layer_solid_surfaces;
     // Current layer processed. In sequential printing mode, only a single copy will be printed.
     // In non-sequential mode, all its copies will be printed.
     const Layer*                        m_layer;

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -310,6 +310,8 @@ private:
     void            add_wipe_points(const std::vector<THING>& paths, bool reverse, bool is_loop);
     void            seam_notch(const ExtrusionLoop& original_loop, ExtrusionPaths& building_paths,
         ExtrusionPaths& notch_extrusion_start, ExtrusionPaths& notch_extrusion_end, bool is_hole_loop, bool is_full_loop_ccw);
+    void            perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
+    void            perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
 
 
 	struct InstanceToPrint
@@ -472,6 +474,12 @@ private:
     uint32_t                            m_layer_with_support_count;
     // Progress bar indicator. Increments from -1 up to layer_count.
     int                                 m_layer_index;
+    // Sequential index of the current perimeter being printed within a layer
+    size_t                              m_perimeter_index{0};
+    bool                                m_apply_inside_layer{false};
+    // Current object layer and instance index for obstacle tracking
+    size_t                              m_current_object_layer_idx{0};
+    size_t                              m_current_instance_idx{0};
     // Current layer processed. In sequential printing mode, only a single copy will be printed.
     // In non-sequential mode, all its copies will be printed.
     const Layer*                        m_layer;

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -310,8 +310,8 @@ private:
     void            add_wipe_points(const std::vector<THING>& paths, bool reverse, bool is_loop);
     void            seam_notch(const ExtrusionLoop& original_loop, ExtrusionPaths& building_paths,
         ExtrusionPaths& notch_extrusion_start, ExtrusionPaths& notch_extrusion_end, bool is_hole_loop, bool is_full_loop_ccw);
-    void            perimeter_inside_start(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
-    void            perimeter_inside_end(ExtrusionPaths& paths, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
+    void            perimeter_inside_start(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
+    void            perimeter_inside_end(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
 
 
 	struct InstanceToPrint

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -305,7 +305,7 @@ private:
     std::string     extrude_path(const ExtrusionPath &path, const std::string_view description, double speed = -1.);
     std::string     extrude_path_3D(const ExtrusionPath3D &path, const std::string_view description, double speed = -1.);
 
-    void            split_at_seam_pos(ExtrusionLoop &loop, bool was_clockwise, size_t perimeter_idx);
+    void            split_at_seam_pos(ExtrusionLoop &loop, bool was_clockwise);
     template <typename THING = ExtrusionEntity> // can be templated safely because private
     void            add_wipe_points(const std::vector<THING>& paths, bool reverse, bool is_loop);
     void            seam_notch(const ExtrusionLoop& original_loop, ExtrusionPaths& building_paths,
@@ -474,9 +474,7 @@ private:
     uint32_t                            m_layer_with_support_count;
     // Progress bar indicator. Increments from -1 up to layer_count.
     int                                 m_layer_index;
-    // Seam positions from the previous layer and for the layer being processed
-    std::vector<Point>                  m_last_seam_positions;
-    std::vector<Point>                  m_curr_seam_positions;
+    size_t                              m_perimeter_index{0};
     bool                                m_apply_inside_layer{false};
     // Current object layer and instance index for obstacle tracking
     size_t                              m_current_object_layer_idx{0};

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -312,7 +312,6 @@ private:
         ExtrusionPaths& notch_extrusion_start, ExtrusionPaths& notch_extrusion_end, bool is_hole_loop, bool is_full_loop_ccw);
     void            perimeter_inside_start(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
     void            perimeter_inside_end(ExtrusionPaths& paths, const Polygon* fallback_poly, bool is_hole_loop, bool is_full_loop_ccw, double nozzle_diam, std::string& gcode, double speed);
-    coordf_t        limit_by_island(const Point& start, const Vec2d& normal, coordf_t dist) const;
 
 
 	struct InstanceToPrint

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -474,9 +474,9 @@ private:
     uint32_t                            m_layer_with_support_count;
     // Progress bar indicator. Increments from -1 up to layer_count.
     int                                 m_layer_index;
-    // Sequential index of the current perimeter being printed within a layer
-    size_t                              m_perimeter_index{0};
+    // Seam positions from the previous layer and for the layer being processed
     std::vector<Point>                  m_last_seam_positions;
+    std::vector<Point>                  m_curr_seam_positions;
     bool                                m_apply_inside_layer{false};
     // Current object layer and instance index for obstacle tracking
     size_t                              m_current_object_layer_idx{0};

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -305,7 +305,7 @@ private:
     std::string     extrude_path(const ExtrusionPath &path, const std::string_view description, double speed = -1.);
     std::string     extrude_path_3D(const ExtrusionPath3D &path, const std::string_view description, double speed = -1.);
 
-    void            split_at_seam_pos(ExtrusionLoop &loop, bool was_clockwise);
+    void            split_at_seam_pos(ExtrusionLoop &loop, bool was_clockwise, size_t perimeter_idx);
     template <typename THING = ExtrusionEntity> // can be templated safely because private
     void            add_wipe_points(const std::vector<THING>& paths, bool reverse, bool is_loop);
     void            seam_notch(const ExtrusionLoop& original_loop, ExtrusionPaths& building_paths,
@@ -476,6 +476,7 @@ private:
     int                                 m_layer_index;
     // Sequential index of the current perimeter being printed within a layer
     size_t                              m_perimeter_index{0};
+    std::vector<Point>                  m_last_seam_positions;
     bool                                m_apply_inside_layer{false};
     // Current object layer and instance index for obstacle tracking
     size_t                              m_current_object_layer_idx{0};

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -6845,6 +6845,24 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvancedE | comSuSi;
     def->is_vector_extruder = true;
     def->set_default_value(new ConfigOptionPercents{ 50 });
+
+    def = this->add("extrude_perimeter_inside", coBools);
+    def->label = L("Extrude perimeter inside");
+    def->category = OptionCategory::extruders;
+    def->tooltip = L("Extrude a short segment inside the object before starting and after finishing external perimeters.");
+    def->mode = comAdvancedE | comSuSi;
+    def->is_vector_extruder = true;
+    def->set_default_value(new ConfigOptionBools{ false });
+
+    def = this->add("extrude_perimeter_inside_length", coFloats);
+    def->label = L("Extrude inside length");
+    def->category = OptionCategory::extruders;
+    def->tooltip = L("Length of the inside extrusion segment for the perimeter start/end.");
+    def->sidetext = L("mm");
+    def->min = 0;
+    def->mode = comAdvancedE | comSuSi;
+    def->is_vector_extruder = true;
+    def->set_default_value(new ConfigOptionFloats{ 0.5f });
     
     def = this->add("wipe_lift", coFloatsOrPercents);
     def->label = L("Wipe lift");
@@ -7379,6 +7397,8 @@ void PrintConfigDef::init_extruder_option_keys()
     m_extruder_option_keys = {
         "default_filament_profile",
         "deretract_speed",
+        "extrude_perimeter_inside",
+        "extrude_perimeter_inside_length",
         "extruder_colour",
         "extruder_extrusion_multiplier_speed",
         "extruder_fan_offset",
@@ -7423,6 +7443,8 @@ void PrintConfigDef::init_extruder_option_keys()
 
     m_extruder_retract_keys = {
         "deretract_speed",
+        "extrude_perimeter_inside",
+        "extrude_perimeter_inside_length",
         "retract_before_travel",
         "retract_before_wipe",
         "retract_layer_change",
@@ -7457,6 +7479,8 @@ void PrintConfigDef::init_extruder_option_keys()
     assert(std::is_sorted(m_extruder_retract_keys.begin(), m_extruder_retract_keys.end()));
     m_filament_override_option_keys = {
         "deretract_speed",
+        "extrude_perimeter_inside",
+        "extrude_perimeter_inside_length",
         "retract_before_travel",
         "retract_before_wipe",
         "retract_layer_change",

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1086,6 +1086,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionPercents,            extruder_fan_offset))
     ((ConfigOptionPoints,              extruder_offset))
     ((ConfigOptionFloats,              extruder_temperature_offset))
+    ((ConfigOptionBools,               extrude_perimeter_inside))
+    ((ConfigOptionFloats,              extrude_perimeter_inside_length))
     ((ConfigOptionString,              extrusion_axis))
     ((ConfigOptionFloats,              extrusion_multiplier))
     ((ConfigOptionFloat,               fan_kickstart))


### PR DESCRIPTION
## Summary
- keep a flag to continue inside extrusions once activated within a layer
- reset this flag when starting or finishing perimeters
- apply the flag when deciding whether to clip and extrude inside moves
- match seam point using an epsilon so overhang loops trigger the feature
- ensure a minimum fallback distance is used for inside start distance
- when seam lookup fails (e.g. loop split by overhangs) fall back to neighbor points so the perpendicular move still executes
- scale the loop clipping offset based on the perimeter index so successive perimeters don't overlap

## Testing
- `make test` *(fails: No rule to make target 'test'.  Stop.)*
- `ctest --output-on-failure -j$(nproc)` *(fails: No tests were found!!!)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6870bfee8ab4832cba9cc7086d60e28a