### PR TITLE
Add GUI control for seam overhang avoidance

### DIFF
--- a/resources/ui_layout/default/print.ui
+++ b/resources/ui_layout/default/print.ui
@@ -79,9 +79,11 @@ group:sidetext_width$5:Seam
 		setting:tags$Simple$Advanced$Expert$Prusa$SuSi:script:enum$corners$Corners$nearest$Nearest$random$Scattered$allrandom$Random$aligned$Aligned$contiguous$Contiguous$rear$Rear$custom$Custom:depends$seam_position$seam_angle_cost$seam_travel_cost:label$Seam position:label_width$12:sidetext_width$0:tooltip$Position of perimeters' starting points. May use the angle & travel cost (with the fixed visilibity & ovehangs cost) to find the best place.\nCorners\. at least 100% angle cost and no more than 80% travel cost (default to 120-40).\nNearest\. no more than 100% angle cost and at least 100% travel cost (default to 80-100).\nScattered\. seam is placed at a random position on external perimeters.\nRandom\. seam is placed at a random position for all perimeters.\nAligned\. seams are grouped in the best place possible (minimum 6 layers per group).\nContiguous\. seam is placed over a seam from the previous layer (useful with enforcers as seeds).\nRear\. seam is placed at the far side (highest Y coordinates).\nCustom\. Other conbination of angle & travel cost than 'Corners' and 'Nearest', (default to 60-100).\nCustom & weight can be defined in Advanced or Expert mode.:s_seam_position:s_seam_position
 #		setting:tags$Expert:label_width$12:sidetext_width$0:seam_position
 		setting:tags$Advanced$Expert$SuSi:width$3:sidetext_width$0:seam_angle_cost
-		setting:tags$Advanced$Expert$SuSi:width$3:sidetext_width$0:seam_travel_cost
-		setting:tags$Expert$SuSi:sidetext_width$0:seam_visibility
-	end_line
+                setting:tags$Advanced$Expert$SuSi:width$3:sidetext_width$0:seam_travel_cost
+                setting:tags$Expert$SuSi:sidetext_width$0:seam_visibility
+                setting:tags$Expert$SuSi:sidetext_width$0:seam_avoid_overhangs
+                setting:tags$Expert$SuSi:width$3:sidetext_width$0:seam_overhang_cost
+        end_line
 	setting:staggered_inner_seams
 	line:Seam notch
 		setting:seam_notch_inner

--- a/src/libslic3r/GCode/SeamPlacer.cpp
+++ b/src/libslic3r/GCode/SeamPlacer.cpp
@@ -949,6 +949,7 @@ struct SeamComparator {
     float angle_importance = 1.f;
     float travel_importance = 1.f;
     float visibility_importance = 1.f;
+    float overhang_importance = 1.f;
     Point seam_mod_pos;
     explicit SeamComparator(SeamPosition setup, const PrintObject& po) :
             setup(setup) {
@@ -966,6 +967,10 @@ struct SeamComparator {
         visibility_importance = (po.config().seam_visibility.value &&
                                  po.config().seam_position.value == SeamPosition::spCost) ?
                                     1.f :
+                                    0.f;
+        overhang_importance = (po.config().seam_avoid_overhangs.value &&
+                               po.config().seam_position.value == SeamPosition::spCost) ?
+                                    (float)po.config().seam_overhang_cost.get_abs_value(1.f) :
                                     0.f;
     }
 
@@ -1013,11 +1018,11 @@ struct SeamComparator {
         }
 
         // the penalites are kept close to range [0-1.x] however, it should not be relied upon
-        float penalty_a = overhang_penalty_a
+        float penalty_a = overhang_importance * overhang_penalty_a
                 + visibility_importance * a.visibility
                 + angle_importance * compute_angle_penalty(a.local_ccw_angle)
                 + travel_importance * distance_penalty_a;
-        float penalty_b = overhang_penalty_b
+        float penalty_b = overhang_importance * overhang_penalty_b
                 + visibility_importance * b.visibility
                 + angle_importance * compute_angle_penalty(b.local_ccw_angle)
                 + travel_importance * distance_penalty_b;
@@ -1048,8 +1053,9 @@ struct SeamComparator {
         }
 
         //avoid overhangs
-        if ((a.overhang > 0.0f || b.overhang > 0.0f)
-                && abs(a.overhang - b.overhang) > (0.1f * a.perimeter.flow_width)) {
+        if (overhang_importance > 0.f &&
+            (a.overhang > 0.0f || b.overhang > 0.0f) &&
+            abs(a.overhang - b.overhang) > (0.1f * a.perimeter.flow_width)) {
             return a.overhang < b.overhang;
         }
 
@@ -1069,9 +1075,9 @@ struct SeamComparator {
             return a.position.y() + SeamPlacer::seam_align_score_tolerance * 5.0f > b.position.y();
         }
 
-        float penalty_a = a.overhang + a.visibility
+        float penalty_a = overhang_importance * a.overhang + a.visibility
                 + angle_importance * compute_angle_penalty(a.local_ccw_angle);
-        float penalty_b = b.overhang + b.visibility +
+        float penalty_b = overhang_importance * b.overhang + b.visibility +
                 angle_importance * compute_angle_penalty(b.local_ccw_angle);
 
         return penalty_a <= penalty_b || penalty_a - penalty_b < SeamPlacer::seam_align_score_tolerance;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -520,6 +520,8 @@ static std::vector<std::string> s_Preset_print_options {
         "seam_notch_outer",
         "seam_travel_cost",
         "seam_visibility",
+        "seam_avoid_overhangs",
+        "seam_overhang_cost",
         "staggered_inner_seams",
         // external_perimeters
         "external_perimeters_first",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -499,6 +499,25 @@ void PrintConfigDef::init_common_params()
     def->mode = comExpert | comSuSi;
     def->set_default_value(new ConfigOptionBool(true));
 
+    def = this->add("seam_avoid_overhangs", coBool);
+    def->label = L("avoid overhangs");
+    def->full_label = L("Avoid overhangs during seam placement");
+    def->category = OptionCategory::perimeter;
+    def->tooltip = L("When enabled, seam points located on overhang perimeters are penalized.");
+    def->mode = comExpert | comSuSi;
+    def->set_default_value(new ConfigOptionBool(true));
+
+    def = this->add("seam_overhang_cost", coPercent);
+    def->label = L("Overhang cost");
+    def->full_label = L("Seam overhang cost");
+    def->category = OptionCategory::perimeter;
+    def->tooltip = L("Strength of the penalty applied to seam points located on overhangs.");
+    def->sidetext = L("%");
+    def->min = 0;
+    def->max = 1000;
+    def->mode = comExpert | comSuSi;
+    def->set_default_value(new ConfigOptionPercent(100));
+
     def = this->add("thumbnails_format", coEnum);
     def->label = L("Format of G-code thumbnails");
     def->tooltip = L("Format of G-code thumbnails: PNG for best quality, JPG for smallest size, QOI for low memory firmware");
@@ -10030,6 +10049,8 @@ std::unordered_set<std::string> prusa_export_to_remove_keys = {
 "seam_notch_outer",
 "seam_travel_cost",
 "seam_visibility",
+"seam_avoid_overhangs",
+"seam_overhang_cost",
 "skirt_brim",
 "skirt_distance_from_brim",
 "skirt_extrusion_width",

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -797,6 +797,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloatOrPercent,       seam_notch_inner))
     ((ConfigOptionFloatOrPercent,       seam_notch_outer))
     ((ConfigOptionBool,                 seam_visibility))
+    ((ConfigOptionBool,                 seam_avoid_overhangs))
+    ((ConfigOptionPercent,              seam_overhang_cost))
 //    ((ConfigOptionFloat,                seam_preferred_direction))
 //    ((ConfigOptionFloat,                seam_preferred_direction_jitter))
     ((ConfigOptionFloat,                slice_closing_radius))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1666,6 +1666,8 @@ bool PrintObject::invalidate_state_by_config_options(
                 || opt_key == "seam_notch_outer"
                 || opt_key == "seam_travel_cost"
                 || opt_key == "seam_visibility"
+                || opt_key == "seam_avoid_overhangs"
+                || opt_key == "seam_overhang_cost"
                 || opt_key == "small_area_infill_flow_compensation_model"
                 || opt_key == "small_perimeter_speed"
                 || opt_key == "small_perimeter_min_length"

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -397,7 +397,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     for (auto el : { "thin_walls_min_width", "thin_walls_overlap", "thin_walls_merge" })
         toggle_field(el, have_thin_wall && config->opt_bool("thin_walls"));
 
-    for (auto el : { "seam_angle_cost", "seam_travel_cost", "seam_visibility" })
+    for (auto el : { "seam_angle_cost", "seam_travel_cost", "seam_visibility",
+                      "seam_avoid_overhangs", "seam_overhang_cost" })
         toggle_field(el, have_perimeters && config->option<ConfigOptionEnum<SeamPosition>>("seam_position")->value == SeamPosition::spCost);
 
     toggle_field("perimeter_loop_seam", have_perimeter_loop);


### PR DESCRIPTION
## Summary
- expose seam overhang avoidance parameters in settings
- add UI controls for new options
- use new settings when placing seams

## Testing
- `cmake -S . -B build` *(fails: Could NOT find DBus)*

------
https://chatgpt.com/codex/tasks/task_e_6873600401c4832c91cfaced8a27d22b